### PR TITLE
Added support for canonincal url in posts

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -107,7 +107,11 @@
          {{ with $.Site.GetPage (printf " /%s/%s" "tags" . ) }} {{- .Title -}} {{- end }} {{- end }} {{- end }}" />
 
 <!-- Canonical URLs -->
-<link rel="canonical" href="{{ .Permalink }}" />
+{{ if .Params.canonicalUrl }}
+<link rel="canonical" href="{{ .Params.canonicalUrl }}">
+{{ else }}
+<link rel="canonical" href="{{ .Permalink }}">
+{{ end }}
 <link rel="alternate" href="{{ .Permalink }}" hreflang="{{ .Site.LanguageCode }}" />
 
 <!-- Links to RSS Feed -->


### PR DESCRIPTION
## Category

- [ ] Content fix
- [ ] New article
- [x] New feature

## Contents of the Pull Request
After talking to @LuiseFreese on twitter I decided to do some research on how to add canonical url to a hugo template. Luckily it was easy. So here is the new feature (if you can call it that). 

For reference. [this is the blogpost I found that described how to do it](https://cconcannon.medium.com/adding-an-external-canonical-url-to-a-hugo-template-3b6e18814649). I tested locally and when adding a canonicalUrl in the metadata section of the post it will be generated in the header of the static site in the /public folder when generated.


## Guidance
You can now add a canonicalURL like described in the code snippet below, and it will generate a <link rel="canonical"> in the header section of the page. 
```yaml
....
tags: ["Azure"]
type: "regular"
canonicalURL: "https://url-to-where-the-content-originale-was-posted.com"
```

will result in this line in header if the canonicalURL is set
```html
<link rel="canonical" href="https://elischei.com/test">
<link rel="alternate" href="https://pnp.github.io/blog/post/testing-canonical-url/" hreflang="en-us" />
```
and if the canonicalURL is not set it will simply set the canonical to the current site
```html
<link rel="canonical" href="https://pnp.github.io/blog/post/testing-canonical-url/">
```

