### PR TITLE
Fixed styling on links to make them WCAG compliant

### DIFF
--- a/assets/scss/_common.scss
+++ b/assets/scss/_common.scss
@@ -28,12 +28,18 @@ img {
   border: 0;
 }
 
-a,
-a:hover,
-a:focus {
-  text-decoration: none;
+a{
+  color: var(--theme-hyperlink);
+  text-decoration: underline;
+  &:focus{
+    border: 1px solid var(--theme-hyperlink);
+  }
 }
-
+.widget-list, .widget-list-inline{
+  a{
+    text-decoration: none;
+  }
+}
 a,
 button,
 select {
@@ -46,7 +52,18 @@ select {
 }
 
 a:hover {
-  color: $primary-color;
+  text-decoration: none;
+}
+h1, h2, h3, h4, h5 {
+  a{
+    text-decoration: none;
+    &:hover{
+      text-decoration: underline;
+    }
+    &:focus{
+      text-decoration: underline;
+    }
+  }
 }
 
 .slick-slide {


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article


## Contents of the Pull Request
I noticed that the links on the blog was not compliant with WCAG standars. A link should be marked with more than just color. So I added an underline to links in blogposts - and underline on hover for headings on frontpage. 
I also changed the link color to a darker blue (that was already set in the --theme-hyperlink variable), since the one that were being used did not have a good enough contrast to be wcag complient.

I also added focus style since it was impossible to navigate around the blog using just a keyboard. Just try it on the live version to day - you are basically blind and can't see where you are when you try to tab-navigate. 
I added a small border to fucus state. We could ofcourse work on some more visually pleasing way to make the focus visible, but for now I thought it was most important to get a fix that makes it possible to navigate without getting lost. :) 

**Note**, I only checked frontpage and some blogpost when I ran the blog locally. Let me know if there are links somewhere else on the site that should be handled different too. :)

## Guidance

Here are some links that describe the wcag criteria.

Use of non-color indicators of links
* https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html 
* https://www.w3.org/TR/WCAG20-TECHS/F73.html 

Color contrast
* https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html

Visible focus 
* https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html 
