### PR TITLE
Fix issue with not installing the right version of Hugo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y ca-certificates openssl git curl && \
     export ARCH=64bit ;; \
     esac && \
     echo ${ARCH} && \
-    wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_${VERSION}_Linux-${ARCH}.tar.gz && \
+    wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_extended_${VERSION}_Linux-${ARCH}.tar.gz && \
     tar xf ${VERSION}.tar.gz && \
     mv hugo /usr/bin/hugo
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,9 +12,9 @@
 			// Update VERSION to pick a specific hugo version.
 			// Example versions: latest, 0.73.0, 0,71.1
 			// Rebuild the container if it already exists to update.
-			"VERSION": "latest",
+			"VERSION": "0.100.2",
 			// Update NODE_VERSION to pick the Node.js version: 12, 14
-			"NODE_VERSION": "14",
+			"NODE_VERSION": "14"
 		}
 	},
 


### PR DESCRIPTION
## Category

- [ ] Content fix
- [ ] New article
- [x] Bug 

## Related issues

- fixes #423

## Contents of the Pull Request

This PR contains an update to the installed version of hugo within the Dockerfile. It will now install the extended version using the same version nr as the release pipeline does.
