### PR TITLE
Added back to pnp home site button

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,10 @@ languageCode = 'en-us'
 baseURL = "https://pnp.github.io/blog"
 title = "Microsoft 365 Platform Community Blog"
 
+[params]
+    PnPHomePageUrl = "https://pnp.github.io/"
+    PnPHomePageName = "PnP Community Home Page"
+
 # Set content editor
 newContentEditor = "code"
 timeout = 90000

--- a/themes/reader-hugo/layouts/partials/header.html
+++ b/themes/reader-hugo/layouts/partials/header.html
@@ -79,6 +79,7 @@
             placeholder="{{ i18n `search_placeholder`}}">
         </form>
         {{ end }}
+        {{ partial "pnp-main-page-link.html" . }}
         {{ partial "gh-link.html" . }}
 
         <!-- collapse button -->

--- a/themes/reader-hugo/layouts/partials/header.html
+++ b/themes/reader-hugo/layouts/partials/header.html
@@ -81,11 +81,6 @@
         {{ end }}
         {{ partial "pnp-main-page-link.html" . }}
         {{ partial "gh-link.html" . }}
-
-        <!-- collapse button -->
-        <button class="navbar-toggler border-0 order-1" type="button" data-toggle="collapse" data-target="#navigation" aria-label="Navbar Button">
-          <i class="fas fa-bars"></i>
-        </button>
       </div>
     </nav>
   </div>

--- a/themes/reader-hugo/layouts/partials/pnp-main-page-link.html
+++ b/themes/reader-hugo/layouts/partials/pnp-main-page-link.html
@@ -1,0 +1,1 @@
+<a href="{{$.Site.Params.PnPHomePageUrl}}" class="nav-link text-decoration-none text-white">{{$.Site.Params.PnPHomePageName}}</a>


### PR DESCRIPTION
## Category

- [X] Content fix

## Related issues

- fixes #155

## Contents of the Pull Request

### 🎯Aim

The aim of this PR is to add some kind of link at the blue top header of the site that will redirect user to the PnP community home site.

### ✅ What was done

- [X] I added new site variables with link url and name for the new header button
- [X] added new simple partial and used it in the header
- [X] removed hamburger button from header

### 📸 Result

![image](https://user-images.githubusercontent.com/58668583/182043670-dec77c2d-78ef-48fa-b6c5-4f15191e5126.png)

🎥 How it works 👇

https://user-images.githubusercontent.com/58668583/182043733-7cb5bc77-7a29-4edd-b24a-a31a3003cdb5.mp4

removed the navigation toggle button from header which had no functionality was black
![image](https://user-images.githubusercontent.com/58668583/182725755-43060c5d-dee6-4f4c-a53d-8de8642f77ad.png)


### 💬 Additional comment
Also 😜... for now the link name is "PnP Community Home Page" as I could not think of anything better but please fell free to suggest a better one