### PR TITLE
Changing the wording for word api survey link.

### DIFF
--- a/content/office-add-ins-community-call/2022-08-10/index.md
+++ b/content/office-add-ins-community-call/2022-08-10/index.md
@@ -44,7 +44,7 @@ The call was hosted by [David Chesnut](http://twitter.com/davidchesnut), Senior 
   
 ## Call to action
 
-* Give us feedback on what you need from Word apis. Join the Teams call. [Survey](aka.ms/WordAPI).
+* If you are a Word developer go ahead and give us feedback on what you need from Word apis. [Word APIs Survey](https://forms.office.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbR6n1U-1y30dHploxSapt6sxUMEdRQUMyU1kzSExENUI1WTIzN1k1WlMxQy4u).
 * Share your feedback on how we can provide you with a better Office Add-ins development experience. Join a community panel. 
     * [Outlook add-ins panel](https://ux.microsoft.com/Panel/OutlookAddinDeveloper)
     * [Excel add-ins panel](https://ux.microsoft.com/Panel/ExcelAddinDeveloper)


### PR DESCRIPTION
## Category

-  [x] Content fix

## Contents of the Pull Request

> Previous wording for call to action to fill out word api survey was confusing so reworded for clarity. 