### PR TITLE
unify tag for "spfx" to a single instance

### DIFF
--- a/content/post/community-sample-engage-your-users-with-sharepoint-stories-reels/index.md
+++ b/content/post/community-sample-engage-your-users-with-sharepoint-stories-reels/index.md
@@ -6,7 +6,7 @@ githubname: luismanez
 categories: ["Community post"]
 images:
 - images/6-component-did-mount.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 

--- a/content/post/community-sample-faqs-with-propertyfieldcollectiondata/index.md
+++ b/content/post/community-sample-faqs-with-propertyfieldcollectiondata/index.md
@@ -6,7 +6,7 @@ githubname: arunkumarperumal
 categories: ["Community post"]
 images:
 - images/FAQWebpart.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 draft: false
 ---

--- a/content/post/community-sample-news-ticker-app-spfx-extensions/index.md
+++ b/content/post/community-sample-news-ticker-app-spfx-extensions/index.md
@@ -6,7 +6,7 @@ githubname: AriGunawan
 categories: ["Community post"]
 images:
 - images/react-application-news-ticker.gif
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 

--- a/content/post/connecting-to-sharepoint-online-to-on-premises-databases-with/index.md
+++ b/content/post/connecting-to-sharepoint-online-to-on-premises-databases-with/index.md
@@ -4,11 +4,11 @@ date: 2021-10-18T04:08:00-04:00
 author: "Simon Doy"
 githubname: SimonDoy
 categories: ["Community post"]
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
-## Introduction 
+## Introduction
 
 Recently we seem to be getting involved in projects after they have gone
 awry. One of our partners reached out asking for help with an issue they
@@ -27,7 +27,7 @@ Several options were discussed which will be covered in the next
 section.
  
  
-## The approach 
+## The approach
 
 So several options were looked at, and as moving the database was
 quickly ruled out, we came up with these two:
@@ -60,7 +60,7 @@ Id Connect to ensure that only authenticated and authorized users can
 access the API. Further protection was provided by setting the API
 behind Azure API Management.
  
-### Authentication 
+### Authentication
 
 For the SharePoint Framework web parts to be able to authenticate with
 the REST API there are a couple of steps that need to be performed:
@@ -103,7 +103,7 @@ this right.
 ]
 ```
 
-### Azure Hybrid Connections 
+### Azure Hybrid Connections
 
 The Azure Hybrid Connection is set up in two places.
 
@@ -125,7 +125,7 @@ which is supported and works really well.
 For information on setting up the Azure Hybrid Connection see the
 following [Microsoft article](https://docs.microsoft.com/azure/app-service/app-service-hybrid-connections).
  
-### Performance 
+### Performance
 
 One of the areas that we wanted to ensure was the performance of the
 application. So we put together a POC was put together to prove the
@@ -140,7 +140,7 @@ optimizations we made were
 -   Using Dapper and performing filtering at the SQL layer rather than
     pulling the data down and filtering in the API
 
-## Conclusion 
+## Conclusion
 
 This solution enables SharePoint Online solutions to access data hosted
 On-Premises in a secure manner which is very effective. I was surprised

--- a/content/post/getting-started-with-sharepoint-framework/index.md
+++ b/content/post/getting-started-with-sharepoint-framework/index.md
@@ -6,7 +6,7 @@ githubname: WaldekMastykarz
 categories: ["Community post"]
 images:
 - images/graph.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
@@ -14,7 +14,7 @@ Using SharePoint Framework you can extend portals on Microsoft 365 and
 expose your apps where people work. Here are some resources to get you
 started.
 
-## What is SharePoint Framework and why should you care 
+## What is SharePoint Framework and why should you care
 
 SharePoint Framework is a development model for building apps on
 Microsoft 365. Originally, it started as a way to extend SharePoint
@@ -23,12 +23,12 @@ When you use SharePoint Framework to build your apps, you don't need to
 worry about hosting and auth. You can build your app using any
 client-side framework you want and easily deploy your app to your users.
 
-## Resources for getting started with SharePoint Framework 
+## Resources for getting started with SharePoint Framework
 
 Here is a list of resources to help you get started with building apps
 using the SharePoint Framework.
 
-### [Introduction to customizing and extending SharePoint](https://docs.microsoft.com/learn/modules/intro-sharepoint-framework/?WT.mc_id=m365-14993-wmastyka) (learn module) 
+### [Introduction to customizing and extending SharePoint](https://docs.microsoft.com/learn/modules/intro-sharepoint-framework/?WT.mc_id=m365-14993-wmastyka) (learn module)
 
 If you like a structured way of learning, this is the best place to
 start. This learn module takes you through the basics of what SharePoint
@@ -39,7 +39,7 @@ that allows you to get certified as a Microsoft 365 developer.
 [View the learn
 module](https://docs.microsoft.com/learn/modules/intro-sharepoint-framework/?WT.mc_id=m365-14993-wmastyka)
 
-### [Hands-on tutorials for SharePoint development](https://docs.microsoft.com/sharepoint/dev/training/training?WT.mc_id=m365-14993-wmastyka) 
+### [Hands-on tutorials for SharePoint development](https://docs.microsoft.com/sharepoint/dev/training/training?WT.mc_id=m365-14993-wmastyka)
 
 If you prefer a more hands-on approach, the SharePoint development
 tutorials and training are another great place to start. There are both
@@ -50,7 +50,7 @@ resource for you to bookmark.
 [View the hands-on tutorials for SharePoint
 development](https://docs.microsoft.com/sharepoint/dev/training/training?WT.mc_id=m365-14993-wmastyka)
 
-### [SharePoint development docs](https://docs.microsoft.com/sharepoint/dev/spfx/sharepoint-framework-overview?WT.mc_id=m365-14993-wmastyka) 
+### [SharePoint development docs](https://docs.microsoft.com/sharepoint/dev/spfx/sharepoint-framework-overview?WT.mc_id=m365-14993-wmastyka)
 
 Once you're past the basics, the official SharePoint Framework is a
 great place to deepen your knowledge. In the docs you will find
@@ -61,7 +61,7 @@ organizations should take into account.
 [View SharePoint Framework
 docs](https://docs.microsoft.com/sharepoint/dev/spfx/sharepoint-framework-overview?WT.mc_id=m365-14993-wmastyka)
 
-### [Microsoft 365 Community](https://pnp.github.io/) 
+### [Microsoft 365 Community](https://pnp.github.io/)
 
 Microsoft 365 has a vibrant community that supports each other in
 building apps on Microsoft 365. We share our experiences through regular
@@ -69,7 +69,7 @@ community calls, offer guidance, record videos and build tools to speed
 up development. You can find everything we have to offer at
 [aka.ms/m365pnp](https://aka.ms/m365pnp).
 
-## Start building your apps on Microsoft 365 today 
+## Start building your apps on Microsoft 365 today
 
 Over 250 million users work with Microsoft 365 and using SharePoint
 Framework is an easy way to bring your application to where people are.

--- a/content/post/getting-started-with-unit-testing-spfx/index.md
+++ b/content/post/getting-started-with-unit-testing-spfx/index.md
@@ -9,7 +9,7 @@ categories: ["Community post"]
 images:
 - images/TestFails.PNG
 # don't change
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 # don't change
 type: "regular"
 ---
@@ -18,7 +18,7 @@ type: "regular"
 
 Contrary to popular belief I don't think unit testing is easy. To be honest, unit testing in SharePoint world is even more difficult than any other.
 Going even further - unit testing SPFx is extremely challenging. If You have ever tried to write unit tests in Your SPFx project I'm sure You can share my opinion.
-The constant stream of enigmatic exceptions can successfully discourage from pursuing the concept all together. 
+The constant stream of enigmatic exceptions can successfully discourage from pursuing the concept all together.
 
 There are some great resources on the topic online, but the problem with them is that they outdate quite quickly. Moreover SPFx changes each version which requires You to understand how the unit tests are working to be able to correctly maintain them.
 
@@ -79,15 +79,15 @@ What is happening here is
 
  * Transforming ts and tsx files using ts-jest - effectively we add support for typescript in our unit tests
  * testRegex - we basically define what files we will consider as a unit test file
- * moduleFileExtensions - we define what files are considered modules in our solution. I would consider it optional, unless You are using some .js files in the solution. The order matters so we want to give typescript files priority over javascript files and jest defaults to js over ts. 
+ * moduleFileExtensions - we define what files are considered modules in our solution. I would consider it optional, unless You are using some .js files in the solution. The order matters so we want to give typescript files priority over javascript files and jest defaults to js over ts.
  * moduleNameMapper - module names we want to stub. This will be the most important configuration entry for us as it's the easiest way to "ignore" SPFx dependencies. Here we just say we don't want to deal with css nor scss files in our tests, so every time they are requested just return requested object name.
 
  ### Class we will test
 
- As I mentioned before in this post we will focus only on data access layer and data manipulation, so what we want to test is if our class to call MS Graph API will correctly construct the search query and map returned object to our document. 
- 
+ As I mentioned before in this post we will focus only on data access layer and data manipulation, so what we want to test is if our class to call MS Graph API will correctly construct the search query and map returned object to our document.
+
  #### Mock and Test
- 
+
  Let's start by building and testing the query. The easiest way to do that is to use [Graph explorer](https://developer.microsoft.com/en-us/graph/graph-explorer). Here we can fine tune our query and get the response we expect from the endpoint.
  Once we are ready I recommend replacing Your tenant name with test, so You won't leak any information about Your tenant. Let's say we want to have a class called GraphDocumentsProvider. Now let's write out test class.
 

--- a/content/post/global-navigation-in-modern-sharepoint-using-spfx-pnp-and-fluent/index.md
+++ b/content/post/global-navigation-in-modern-sharepoint-using-spfx-pnp-and-fluent/index.md
@@ -6,11 +6,11 @@ githubname: dips365
 categories: []
 images:
 - images/GN3.jpg
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
-## Introduction 
+## Introduction
 
 Modern SharePoint architecture gives fantastic OOTB global navigation,
 and hub site navigation has amazing potential to maintain consistency
@@ -46,7 +46,7 @@ Below Artifacts are going to be used,
 -   [Fluent Ui Command
     Bar](https://developer.microsoft.com/fluentui#/controls/web/commandbar)
 
-## Steps 
+## Steps
 
 1.  Configure Terms in Term Stores
 2.  Create Solution for Application Customizer
@@ -205,7 +205,7 @@ export default class GlobalNav extends React.Component<IGlobalNavProps, IGobalNa
     }
     public render(): React.ReactElement<IGlobalNavProps> {
         return (
-            
+
 
                 Hello World
             </div>
@@ -420,7 +420,7 @@ public render(): React.ReactElement<IGlobalNavProps> {
             <>
                 {
                     this.state.terms.length > 0 &&
-                    
+
 
                         <CommandBar  {...CommandBarProps}
                             style={{ width: "100%" }}
@@ -488,7 +488,7 @@ Copy URL which is highlighted in yellow and paste it into the browser.
 ![Global navigation in Modern SharePoint Using SPFx PnP and Fluent UI6.gif](images/Global navigation in Modern SharePoint Using SPFx PnP and Fluent UI6.gif)
 
 
-## Conclusion 
+## Conclusion
 
 We have implemented the SPFx solution and get terms from the term store
 using PnP and render items in the command bar which is fluent UI

--- a/content/post/guidance-on-how-to-use-react-datatable-webpart/index.md
+++ b/content/post/guidance-on-how-to-use-react-datatable-webpart/index.md
@@ -6,7 +6,7 @@ githubname: chandaniprajapati
 categories: []
 images:
 - images/ChandaniPrajapati.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
@@ -88,7 +88,7 @@ Now create a **page** and add web part.
 
  
 
-### **3 Configure properties from property pane configuration** 
+### **3 Configure properties from property pane configuration**
 
  
 
@@ -96,7 +96,7 @@ Now we will configure a web part as below,
 
  
 
-#### 1. First we will configure the List Configuration section 
+#### 1. First we will configure the List Configuration section
 
 -   Change the web part title that you want to show as a header/title.
 -   Select a list that you want to show in data table format
@@ -108,7 +108,7 @@ Now we will configure a web part as below,
 
  
 
-#### **2. Now configure the Search and Sort Section.** 
+#### **2. Now configure the Search and Sort Section.**
 
 -   **Search**
     -   If you will enable search then it will ask the user for which
@@ -126,7 +126,7 @@ Now we will configure a web part as below,
 
 ![Search_Sort_Config.png](images/Search_Sort_Config.png)
 
-####  3. Now we will configure Advanced features. 
+####  3. Now we will configure Advanced features.
 
  
 

--- a/content/post/how-to-add-preconfigured-spfx-teams-tab/index.md
+++ b/content/post/how-to-add-preconfigured-spfx-teams-tab/index.md
@@ -8,7 +8,7 @@ categories: ["Community post"]
 # link to the thumbnail image for the post
 images:
 - images/tianyi-ma-WiONHd_zYI4-unsplash.jpg
-tags: ["SharePoint frameworks (SPFx)", "Microsoft Teams"]
+tags: ["SharePoint Framework (SPFx)", "Microsoft Teams"]
 # don't change
 type: "regular"
 draft: false

--- a/content/post/how-to-convert-html-content-or-file-to-pdf-using-the-muhimbi-api/index.md
+++ b/content/post/how-to-convert-html-content-or-file-to-pdf-using-the-muhimbi-api/index.md
@@ -6,11 +6,11 @@ githubname: chandaniprajapati
 categories: ["Community post"]
 images:
 - images/ChandaniPrajapati_0-1639758794000.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
-## Introduction 
+## Introduction
 
 This article is used whenever you are getting any content from
 SharePoint List/Library or anything else and rendering it in any
@@ -19,7 +19,7 @@ extract CSS as well so here we will create a dynamic HTML (List or Table
 or anything else as per our requirement) and we can add some inline CSS
 as well. So in this article, we will see step-by-step implementations.
 
-## Implementation 
+## Implementation
 
 **1. Register to Muhimbi API**
 To get the trial version API key, Register to
@@ -42,7 +42,7 @@ Move to the above-created directory using:
     cd muhimbi-export-html-content-to-pdf
 
 Now execute the below command to create an SPFx solution:
-    yo @microsoft/sharepoint 
+    yo @microsoft/sharepoint
 It will ask some questions, as shown below,
 
 ![ChandaniPrajapati_0-1639758794000.png](images/ChandaniPrajapati_0-1639758794000.png)
@@ -166,7 +166,7 @@ export class ConvertFileService {
     public convertToPDF(API_Key: string, apiUrl: string, htmlContent: string, fileName: string) {
         const base64data = btoa(htmlContent);
         const postURL = apiUrl;
-        const body = {          
+        const body = {
             "use_async_pattern": false,
             "source_file_name": `${fileName}.html`,
             "source_file_content": base64data,
@@ -301,7 +301,7 @@ export default class MuhimbiExportHtmlContentToPdf extends React.Component<IMuhi
   private htmlContent = `<table style="width:100%;border: 1px solid black;border-collapse: collapse;"">
                           <tr>
                             <th style="border: 1px solid black;border-collapse: collapse;padding: 5px;">Firstname</th>
-                            <th style="border: 1px solid black;border-collapse: collapse;padding: 5px;">Lastname</th> 
+                            <th style="border: 1px solid black;border-collapse: collapse;padding: 5px;">Lastname</th>
                             <th style="border: 1px solid black;border-collapse: collapse;padding: 5px;">Age</th>
                           </tr>
                           <tr>
@@ -354,13 +354,13 @@ export default class MuhimbiExportHtmlContentToPdf extends React.Component<IMuhi
           <PrimaryButton disabled={showLoader ? true : false} style={{ width: '200px', display: 'flex', alignSelf: 'end', marginBottom: '15px' }} text="Download as PDF" onClick={this.exportToPDF} allowDisabledFocus />
           <div dangerouslySetInnerHTML={{ __html: this.htmlContent }} />
         </Stack>
-      
+
     );
   }
 }
 ```
  
-## Output  
+## Output 
 
 ![Muhimbi - Export to pdf.gif](images/Muhimbi - Export to pdf.gif)
  
@@ -369,7 +369,7 @@ Please find my  [source code](https://github.com/chandaniprajapati/muhimbi-expor
 
 
 
-## Summary 
+## Summary
 
 In this article, we have seen the step-by-step implementation of Muhimbi
 API in the SPFx Web part.

--- a/content/post/how-to-determine-web-part-size-with-spfx-v1-12/index.md
+++ b/content/post/how-to-determine-web-part-size-with-spfx-v1-12/index.md
@@ -6,11 +6,11 @@ githubname: yhabersaat
 categories: ["Community post"]
 images:
 - images/web-part-width.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
-## Context 
+## Context
 
 You might know that this new SPFx v1.12 feature has an old story behind
 it. In the past, developers were getting web part's width by
@@ -24,7 +24,7 @@ an **onAfterResize()** event to determine the width of your web part.
 **Note:** In this article, I'm using a web part project with SPFx
 v.1.12 and React framework.
 
-## Determine web part size 
+## Determine web part size
 
 In your web part TS file, you can add the **onAfterResize()** method to
 get notified when the web part is resized (for example when you resize
@@ -99,7 +99,7 @@ when the web part is resized
 Happy coding everyone!
 
 
-## Resources 
+## Resources
 
 [Determine the rendered web part width | Microsoft
 Docs](https://docs.microsoft.com/sharepoint/dev/spfx/web-parts/basics/determine-web-part-width)

--- a/content/post/how-to-set-up-tailwind-css-in-a-spfx-project/index.md
+++ b/content/post/how-to-set-up-tailwind-css-in-a-spfx-project/index.md
@@ -6,7 +6,7 @@ githubname: AriGunawan
 categories: ["Community post"]
 images:
 - images/State of CSS 2020 Survey.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 

--- a/content/post/how-to-use-fluent-ui-react-persona-control-in-spfx/index.md
+++ b/content/post/how-to-use-fluent-ui-react-persona-control-in-spfx/index.md
@@ -6,7 +6,7 @@ githubname: chandaniprajapati
 categories: ["Community post"]
 images:
 - images/Output.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
@@ -19,7 +19,7 @@ image or a composition of the person's initials on a background color),
 their name or identification, and so on. for more details refer to
 [Fluent UI persona](https://developer.microsoft.com/fluentui#/controls/web/persona).
 
-## Scenario  
+## Scenario 
 
 We will create an SPFx web part in the way to fetch users from any
 specific group and render these users using a persona. so let's see
@@ -27,7 +27,7 @@ step-by-step implementation.
 In the end, our output will be like this,
 ![Output.png](images/Output.png)
 
-## Implementation   
+## Implementation  
 
 Open a command prompt\
 Move to the path where you want to create a project\
@@ -44,7 +44,7 @@ Move to the above-created directory using:
 Now execute the below command to create an SPFx solution:
 
 
-    yo @microsoft/sharepoint 
+    yo @microsoft/sharepoint
 
 
 It will ask some questions, as shown below,
@@ -183,7 +183,7 @@ export function RenderProfilePicture(props: IProfilePicProps) {
     }, [props])
 
     return (
-        
+
 
             <Persona
                 imageUrl={profileUrl}
@@ -258,7 +258,7 @@ export default class Spfxpersona extends React.Component<ISpfxpersonaProps, ISpf
             displayName={m.Title}
             getUserProfileUrl={() => this.getUserProfileUrl(m.LoginName)}  ></RenderProfilePicture>
         )}
-      
+
     );
   }
 }
@@ -277,7 +277,7 @@ Now test the webpart in SharePoint-SiteURL +
 
 
 
-## Output 
+## Output
 
 ![Output.png](images/Output.png)
  
@@ -286,7 +286,7 @@ Find here the [full source code
 ](https://github.com/chandaniprajapati/spfx-fluentui-persona).
  
 
-## Summary 
+## Summary
 
 In this article, we have seen the step-by-step implementation of how to
 use a persona card to show the users' profile picture.

--- a/content/post/how-to-use-loader-spinner-in-progress-indicator-in-spfx-using/index.md
+++ b/content/post/how-to-use-loader-spinner-in-progress-indicator-in-spfx-using/index.md
@@ -6,11 +6,11 @@ githubname: chandaniprajapati
 categories: ["Community post"]
 images:
 - images/spfx-loader.gif
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
-## Introduction 
+## Introduction
 
 A Spinner is an outline of a circle that animates around itself
 indicating to the user that things are processing. A Spinner is shown
@@ -26,12 +26,12 @@ Loader. We will use an Office UI fabric Spinner.
 For more information refer to
 [Fluent UI spinner](https://developer.microsoft.com/fluentui#/controls/web/spinner).
 
-## Implementation 
+## Implementation
 
 -   Open a command prompt
 -   Move to the path where you want to create a project
 -   Create a project directory using:
- 
+
 
 
 ```bash
@@ -45,7 +45,7 @@ Move to the above-created directory using:
 ```
 
 Now execute the below command to create an SPFx solution:
-    yo @microsoft/sharepoint 
+    yo @microsoft/sharepoint
 It will ask some questions, as shown below,
 
 ![How To Use LoaderSpinner In SPFx.png](images/How To Use LoaderSpinner In SPFx.png)
@@ -162,7 +162,7 @@ export default class SpfxLoaderWebPart extends BaseClientSideWebPart<ISpfxLoader
 -   And in the **render()** method we will check if state loading is
     true then show Spinner and if the length of items is greater than 0
     then we will show records.
-    
+
 
 ```javascript
 import * as React from 'react';
@@ -243,7 +243,7 @@ export default class SpfxLoader extends React.Component<ISpfxLoaderProps, ISpfxL
 }
 ```
  
-## Output 
+## Output
 
 ![spfx-loader.gif](images/spfx-loader.gif)
  
@@ -252,7 +252,7 @@ Find here the [full source code
 ](https://github.com/chandaniprajapati/react-spfx-loader).  
  
 
-## Summary 
+## Summary
 
 In this article, we have seen how to use Spinner/loading in the SPFx
 webpart.

--- a/content/post/improving-the-page-properties-web-part/index.md
+++ b/content/post/improving-the-page-properties-web-part/index.md
@@ -6,7 +6,7 @@ githubname: mhomol
 categories: ["Community post"]
 images:
 - images/diff-screencap.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
@@ -31,7 +31,7 @@ it and build a new version of this web part. So with this in mind,
 let's lay out our goals with this new web part. We will call it the
 Advanced Page Properties web part. 
 
-## Feature Goals 
+## Feature Goals
 
 Attempt to replicate the functionality of Page Properties with the
 following improvements:
@@ -47,7 +47,7 @@ In other words, we're shooting for this:
 
 ![Screen Shot 2021-04-06 at 2.40.56 PM.png](images/Screen Shot 2021-04-06 at 2.40.56 PM.png)
 
-## Property Pane 
+## Property Pane
 
 For a part like this, it's all about getting the property page figured
 out first. We want this to feel familiar too and not stray too much from
@@ -195,7 +195,7 @@ pane with all it's needed functionality.
   }
 ```
 
-## Our Component and Displaying our fields/values 
+## Our Component and Displaying our fields/values
 
 Our React component needs to properly react to the list of selected
 properties changing. It also needs to react to our theme changing. I
@@ -332,7 +332,7 @@ the array of any need to be done a little differently than the default.
 Our 3 known cases of needing to do something different are
 TaxonomyFieldTypeMulti, MultiChoice and Thumbnail.
 
-## React and Display 
+## React and Display
 
 Our function component returns the following:
 
@@ -479,7 +479,7 @@ I would love to hear about improvements you'd like to see and obviously
 you are more than welcome to contribute. I already have a bit of a list
 of things I'd love to see it do. 
 
-## Other ideas for improvements 
+## Other ideas for improvements
 
 -   Capsules to be linkable to either a search result page or a filtered
     view of site pages (we always get client requests for this)
@@ -490,7 +490,7 @@ of things I'd love to see it do. 
 -   Styling per property (i.e. colorizing per property or something to
     that effect)
 
-## Conclusion 
+## Conclusion
 
 Hopefully, I've gotten you excited about Page Properties again and
 you've learned a little along the way around how the current Page

--- a/content/post/init-api-permissions-for-your-spfx-projects-without-deploying/index.md
+++ b/content/post/init-api-permissions-for-your-spfx-projects-without-deploying/index.md
@@ -6,7 +6,7 @@ githubname: michaelmaillot
 categories: ["Community post"]
 images:
 - images/peoplepicker-ui-fail.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
@@ -33,18 +33,18 @@ you should update your `package-solution.json` file to add required
 permissions and allow them (or ask for validation) in the *API
 access* page.
 
-## Prerequisites 
+## Prerequisites
 
 1.  An Office 365 (Dev) Tenant or a Partner Demo Tenant
 2.  The following Azure AD role at least
     -   Application Administrator
 
-## With Graph API 
+## With Graph API
 
 First, we're going to play with Graph API through the [Microsoft Graph
 Toolkit](https://docs.microsoft.com/fr-fr/graph/toolkit/overview).
 
-### Prepare your sample 
+### Prepare your sample
 
 Init a SPFx project (WebPart one with React, let's call it *HelloApi*),
 then add the Microsoft Graph Toolkit by
@@ -83,7 +83,7 @@ export default class HelloApi extends React.Component<IHelloApiProps, {}> {
 }
 ```
 
-### Run it in remote workbench 
+### Run it in remote workbench
 
 Now run your sample with `gulp serve` and display your web part in your
 remote workbench
@@ -100,7 +100,7 @@ As you can see, it's a 403 error, which is well-known when using Graph
 API endpoints that have not been allowed on the first place.
  
 
-### Add Graph API through UI 
+### Add Graph API through UI
 
 From the Azure portal, display the *Azure Active Directory* (AAD), then
 select the **App Registration** menu and select **All Applications**,
@@ -137,14 +137,14 @@ Don't be surprised if by that way, the permission appears in the
 \"Other permissions granted for \[your tenant\]\": it won't prevent
 your SPFx solution to work.
 
-### Try again 
+### Try again
 
 Now try to use the `PeoplePicker` component again: you'll see that with
 the addition of the Graph API permission, you should be able to use that
 component!
 ![peoplepicker-ui-success.png](images/peoplepicker-ui-success.png)
 
-## With custom API 
+## With custom API
 
 When using a custom API, it's a little bit more tricky but easy to
 handle anyway.
@@ -158,7 +158,7 @@ Instead of bundling and shipping, we'll add the AAD App
 created from the Azure Function Authentication part in the SharePoint
 Service Principal.
 
-### Add your AAD Application to the SharePoint Service Principal 
+### Add your AAD Application to the SharePoint Service Principal
 
 Display again the AAD page, then select the **App Registration** menu,
 select **All Applications** and select  **SharePoint Online Client

--- a/content/post/introducing-react-video-banner-web-part/index.md
+++ b/content/post/introducing-react-video-banner-web-part/index.md
@@ -6,7 +6,7 @@ githubname: derhallim
 categories: ["Community post"]
 images:
 - images/derhallim_0-1620249069072.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 

--- a/content/post/patterns-and-practices-for-spfx-development/index.md
+++ b/content/post/patterns-and-practices-for-spfx-development/index.md
@@ -6,7 +6,7 @@ githubname: Dipesh-Bhanani
 categories: ["Community post"]
 images:
 - images/do-what-is-great.png
-tags: ["SPFx", "SharePoint"]
+tags: ["SharePoint Framework (SPFx)", "SharePoint"]
 type: "regular"
 ---
 
@@ -50,31 +50,31 @@ The first and foremost best practice for SPFx solutions is building solution str
 +-- teams
 ```
 
-* **webparts:** 
+* **webparts:**
 
     * `webparts` folder is created as a part of default scaffolding as mentioned above. This contains main webpart classes and other UI components.
 
-* **services:** 
+* **services:**
 
     * `services` folder contains classes and interfaces to implement core business logic. This is very useful while implementing enterprise grade solutions.
 
-* **models:** 
+* **models:**
 
     * `models` folder contains model/entity classes which can be used to pass the data between components. You can choose the name as 'entities' if you would like.
 
-* **helpers:** 
+* **helpers:**
 
     * `helpers` folder contains static/non-static classes that helps you to execute small reusable functions. i.e. `UIHelper.ts`, `DateHelper.ts`
 
-* **hooks:** 
+* **hooks:**
 
-    * `hooks` folder contains hook components. Hooks are a new addition in React 16.8. They let you use state and other React features without writing a class. You can keep all hooks implementations in this folder which will be used across the solution. 
+    * `hooks` folder contains hook components. Hooks are a new addition in React 16.8. They let you use state and other React features without writing a class. You can keep all hooks implementations in this folder which will be used across the solution.
 
-* **common:** 
+* **common:**
 
     * `common` folder contains classes like Constants.ts, Enums.ts or anything you want to make a common among all.
 
-* **controls:** 
+* **controls:**
 
     * `controls` folder contains common UI classes or function components which will be shared across all webparts in solution. For example, `SpinnerOverlay.tsx` which can be used to display spinner with overlay for long operations.
 
@@ -246,7 +246,7 @@ There are multiple ways to consume these services. One simple example is as foll
 
 let productService: IProductService;
 if (Environment.type === EnvironmentType.Test) {
-    productService = this.context.serviceScope.consume(MockProductService.serviceKey);    
+    productService = this.context.serviceScope.consume(MockProductService.serviceKey);
 } else {
     productService = this.context.serviceScope.consume(ProductService.serviceKey);
 }
@@ -272,7 +272,7 @@ As you see in the above example, productService object will be created based on 
 * These UI components should only contain rendering logic. Do not add any business logic or data access code in these components.
 * You should not add multiple function components/classes to single file.
 * Consider keeping the code minimal in render method.
-* Consider handling exception properly. Log the exception details with logger components and present generic informative message for end-user on screen. 
+* Consider handling exception properly. Log the exception details with logger components and present generic informative message for end-user on screen.
 * Do not hardcode strings including generic messages. Use string labels defined in language files (`en-us.js`) located at `src > webparts > myWebPart > loc`
 * Do not store large objects in session/local storages
 * Consider importing leaf level components while importing third party libraries. For example, if you want to import `PrimayButton` from Office Fabric library, use `import { PrimaryButton } from "@fluentui/react/lib/Button";` rather than `import { PrimaryButton } from "@fluentui/react";`. This will help you to keep your package size compact. This can be very useful in scenarios where you would want to build home page components which are required to be performance effective at first load.

--- a/content/post/react-groups-and-teams-filters/index.md
+++ b/content/post/react-groups-and-teams-filters/index.md
@@ -6,7 +6,7 @@ githubname: ReactIntern
 categories: ["Community post"]
 images:
 - images/img1.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
@@ -38,7 +38,7 @@ this because if I were to filter the AllGroupsresults to private and
 then switch to public and filter that, we're just filtering a filtered
 list and you won't get back any results. AllGroupsresults hold all of
 the results for Groups in my Organization and AllGroupsresultsFiltered
-is the filtered version of that list. 
+is the filtered version of that list.
 
 In other words, when we get back
 the Groups ( both Groups in my Org and My Groups ) we make a copy of
@@ -55,7 +55,7 @@ visibility, and assigns the value to SwitchedALL. Same thing for
 MyGroupResults; It maps through MyGroupResults and filters the groups to
 be the ones that match the visibility you selected. Next, we set the
 state of AllGroupsresultsFiltered and MyGroupResultsFiltered to be
-SwitchedALL and SwitchedMY, respectively. 
+SwitchedALL and SwitchedMY, respectively.
 
 In our case, we selected the
 button with the text 'Private' so AllGroupsresultsFiltered and

--- a/content/post/save-data-to-app-personal-folder/index.md
+++ b/content/post/save-data-to-app-personal-folder/index.md
@@ -12,28 +12,28 @@ description: ""
 summary: ""
 # Taxonomies
 categories: ["Community post"]
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular" # available type (epic, trending, popular, or regular)
 ---
 
 ## What's it all about?
 
-So you have this really cool idea for an Spfx solution, you have the workspace ready, you added all needed dependencies, already made you mind up on the whether it's gonna be react or angular or other, and your just about to write that first line of code when suddenly: 
+So you have this really cool idea for an Spfx solution, you have the workspace ready, you added all needed dependencies, already made you mind up on the whether it's gonna be react or angular or other, and your just about to write that first line of code when suddenly:
 
 *"hmmm…. Where I will store my applications user data?"*
 
-As your app will save some data right? Well most of the apps do, and usually the data saved is somehow personal (in context of the current user) so maybe you will be interested in approach I would like to describe in a bit more detail in this article 😀. 
+As your app will save some data right? Well most of the apps do, and usually the data saved is somehow personal (in context of the current user) so maybe you will be interested in approach I would like to describe in a bit more detail in this article 😀.
 
 ## What options do we have?
 
-Let's see some of them we may use. 
+Let's see some of them we may use.
 
 - One of the easiest and I think most common approach we may take is storing data in a SharePoint list we may create while provisioning the Spfx (the Spfx package could provision this as asset or some PnP.PowerShell/CLI for Microsoft 365 will do the trick). We will need to consider if the list is going to be somehow hidden. How we should manage storing data per user? Should we create folder per user data. If so, what about permissions? Probably each user should have read permissions only to their own folder. And what's more important is where we keep the list? On each site where the webpart will be added… rather not. Better to have some one site we store the data. Ok, but potentially we want our solution to be not only for SharePoint but Teams and maybe in near future other places as well. Will storing the data in a SharePoint list be the most logical place then? Also managing the data might be a challenge. I mean should we create a column for every peace of metadata our app will store. Probably yes, but then if we want to store more data in future, we will need to probably add more columns. And doesn't this all seem like using SharePoint list as a database which we is a huge “no no”…. Ok fine let's consider something else.
 - Ok lets think of a more common place. What about Dataverse. Seems like a well prepared, common database. TBH this seems like perfect for a solution done within Power Platform but for an Spfx solution…hmm…. I don't know. I never seen a Spfx webpart which saved/retrieved data from Dataverse. But maybe that's bad and it is a good idea to investigate for future, even if now doesn't seem like a common approach. Lets leave this as open point and research this later. For now seems more like a perfect place for a Power App rather than a Spfx webpart.
 - Ok moving on, what we could also do is add a custom user profile property and store the data there. Creating the custom property might be a challenge as I believe we would need to do it manually, so not a very good use case for and CI/CD pipeline. And if you also had this idea I think there is a very good chance you previously have been working (or still are working) in the On-Prem world right? Seems like a way to go in the good old feature model with a couple of CSOM lines in C#, but doesn't seem like a perfect fit for Spfx. Wouldn't you agree?
 
-Don't get me wrong, all of the above are good ideas for sure. But is there a better common place for each user to store her or his personal data? Well what about OneDrive. Also, is there someway we could save our data in a dynamic structure that we may change in future in an easy way (adding more metadata, like more columns or something like that), which is easy to 'parse' to an object? Well what about XML… only joking… I was going to say JSON. 
-Well, did you know we may use MS Graph and the 
+Don't get me wrong, all of the above are good ideas for sure. But is there a better common place for each user to store her or his personal data? Well what about OneDrive. Also, is there someway we could save our data in a dynamic structure that we may change in future in an easy way (adding more metadata, like more columns or something like that), which is easy to 'parse' to an object? Well what about XML… only joking… I was going to say JSON.
+Well, did you know we may use MS Graph and the
 
 ```
 /me/drive/special/approot:/${YourFileNameHere}
@@ -44,19 +44,19 @@ endpoint for all that? Ye, it creates a folder for you app automagically - I mea
 
 ## How to get started?
 
-Lets start with a bit of experimenting to try it out in the [graph explorer](https://developer.microsoft.com/graph/graph-explorer) (If you haven't used it before, the graph explorer is a perfect place to test out different MS Graph API requests and also, after login, you may do it in the context of your tenant, which is really cool). 
+Lets start with a bit of experimenting to try it out in the [graph explorer](https://developer.microsoft.com/graph/graph-explorer) (If you haven't used it before, the graph explorer is a perfect place to test out different MS Graph API requests and also, after login, you may do it in the context of your tenant, which is really cool).
 
 Ok so lets run a simple GET request
 
 ```
 https://graph.microsoft.com/v1.0/me/drive/special/approot
-``` 
+```
 
-And see what happens. 
+And see what happens.
 
 ![requestToAppRoot](images/requestToAppRoot.png)
 
-Ok success, that's nice, but what actually happened. In the response we will see a 'webUrl' param where we may see the 
+Ok success, that's nice, but what actually happened. In the response we will see a 'webUrl' param where we may see the
 
 ```
 me/drive/special/approot
@@ -73,8 +73,8 @@ And if we go there we see
 ![oneDriveFolders](images/oneDriveFolders.png)
 
 … hey… a new folder in my personal OneDrive, now that’s nice. In the response we may also find that the folder was created by 'Graph Explorer' app and currently `childcount` is zero.
-Ok so that's pretty sweet. With this single request I have a personal folder created for me in the user OneDrive. Isn't it a perfect place to save user defined data? 
- 
+Ok so that's pretty sweet. With this single request I have a personal folder created for me in the user OneDrive. Isn't it a perfect place to save user defined data?
+
 Ok so lets see how to do that.
 In order to add a new .json file with some data we need to run a PUT request
 
@@ -91,14 +91,14 @@ and in the request body we need to provide some JSON structure string like
 As a result we see a new file added to the catalog with your json object. Also we may use the same request to update the data and since it is JSON we may change the data schema how we want quite dynamically. Adding new properties becomes easy.
 
 ![putRequest](images/putRequest.png)
- 
+
 Ok so now lets see how to get our saved data. For this we need another GET request:
 
 ```
 https://graph.microsoft.com/v1.0/me/drive/special/approot:/{YOURFILENAMEHERE}.json
 ```
 
-In the response section you should see `@microsoft.graph.downloadUrl` property. 
+In the response section you should see `@microsoft.graph.downloadUrl` property.
 
 ![getData](images/getData.png)
 
@@ -107,22 +107,18 @@ Click on that link and see what happens
 ![downloadFile](images/downloadFile.png)
 
 … ye our JSON file is downloaded. In the app we may use this approach to get the `.text()` from the response and parse the JSON object back to our model. So in general in our app we will actually need two steps (two requests) to retrieve the data.
- 
+
 There you have it. With a couple of simple requests I was able to create a folder for may data, save it as a .json file in the user OneDrive apps personal folder, and finally get the data back. If only there was some ready to use Spfx sample with some kind of library abstraction that does all that with simple *saveData()*, *getData()* methods, right? Well lucky for you, not that long ago I added a new sample in the *'pnp/sp-dev-fx-webparts'* repo with and Spfx library component that does all this logic for you and a simple webpart which just uses the methods get/save our json object. If you are interested take a look at [react-save-to-onedrive-app-personal-folder sample](https://github.com/pnp/sp-dev-fx-webparts/tree/main/samples/react-save-to-onedrive-app-personal-folder).
 
 ![manageDataLibraryMethods](images/manageDataLibraryMethods.png)
- 
-Before you start creating an Spfx solution that uses this approach there are two things we need to remember. 
+
+Before you start creating an Spfx solution that uses this approach there are two things we need to remember.
 First one, and this is quite obvious, as we are using MS Graph here, our webpart/library will need to request *webApiPermissionRequests* for *Sites.ReadWrite.All* scope which we may add in the *package-solution.json* config. Then of course, after the app is deployed we need to approve this permission request in the SharePoint admin web api management page.
 
 Second one is not that obvious at first but is quite logical. As the Graph request creates the application folder for us we don't have control over the name. As a result of that each Spfx solution will save it's files in the same place (same folder), which name will be *'SharePoint Online Client Extensibility Web Application Principal'* so it would be a good idea to first create a subfolder for your current solution and store the .json file there. That way we may avoid future problems if we have two (or more) Spfx solutions which save data as .json files with the same name (Saving the data from one Spfx webpart would completely overwrite the data saved by the other one).
 
 ![subFolders](images/subFolders.png)
 
-## So what I actually learned after reading this? 
+## So what I actually learned after reading this?
 
 Not sure. Probably if you've been working with Spfx for some time now you already know this approach or already have all the needed skills to use this. But if you haven't used this approach I strongly encourage you to give it a shot. Saving data in user application personal OneDrive folder is a pretty sweet approach which sometimes may be a perfect fit for your solution so it’s good to be familiar with this method
-
-
-
-

--- a/content/post/spfx-image-editor-sample-playing-with-canvas/index.md
+++ b/content/post/spfx-image-editor-sample-playing-with-canvas/index.md
@@ -5,7 +5,7 @@ author: "Peter Paul Kirschner"
 categories: ["Community post"]
 images:
 - images/Screenshot 2021-03-22 at 21.42.06.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
@@ -120,7 +120,7 @@ const img= new Image()
   const oldheight =c.height = img.height;
   const degree=20;
   const radian=degree*Math.PI/180 //Radian
-  
+
   const a = oldwidth * Math.abs(Math.cos(radian));
   const b =  oldheight * Math.abs(Math.sin(radian));
   const p = oldwidth * Math.abs(Math.sin(radian));
@@ -132,18 +132,18 @@ const img= new Image()
    const offsetheight = (newheight - oldheight) / 2;
     c.width = newwidth;
     c.height = newheight;
-  
+
   ctx.translate(newwidth/2,newheight/2);
   ctx.rotate(radian);
   ctx.translate(-newwidth/2,-newheight/2);
-  
+
   ctx.fillStyle = "#0078d4";
   ctx.fillRect(offsetwidth,offsetheight,oldwidth,oldheight);
-  
+
   ctx.drawImage(img, offsetwidth, offsetheight);
    ctx.font = "30px Arial";
   ctx.strokeText("Hello PnP-Community",offsetwidth+10,offsetheight+50);
-  
+
 }
 ```
 
@@ -157,4 +157,3 @@ Try it [sp-dev-fx-webparts/samples/react-image-editor at master ·
 pnp/sp-dev-fx-webparts
 (github.com)](https://github.com/pnp/sp-dev-fx-webparts/tree/master/samples/react-image-editor)
  
-

--- a/content/post/spfx-webpart-form-validation-using-react-formik/index.md
+++ b/content/post/spfx-webpart-form-validation-using-react-formik/index.md
@@ -5,19 +5,19 @@ author: "Chandani Prajapati"
 categories: ["Community post"]
 images:
 - images/Output.png
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
 ---
 
 
-## Introduction 
+## Introduction
 
 Formik is the world's most popular open-source form library for React
 and React Native. We can also use this library in our SPFx web part as
 well to manage form validations. Using this library we don't have to
 write custom validations. so let's start step-by-step implementation.
 
-### What is formik? 
+### What is formik?
 
 Formik is a small library that helps us with the these parts: Getting
 values in and out of form state. Validation and error messages. Handling
@@ -41,7 +41,7 @@ Formik](https://www.c-sharpcorner.com/article/manage-forms-in-react-with-formik/
 **[Formik validation
 Schema](https://formik.org/docs/guides/validation "Formik validation Schema") **
 
-## SharePoint List Structure 
+## SharePoint List Structure
 
 Create a list called **Tasks **with below fields,
   ------------------------------- ---------------------------
@@ -55,7 +55,7 @@ Create a list called **Tasks **with below fields,
 After the creation of the list, we will start to create the SPFx web
 part.
 
-## Formik implementation with SPFx 
+## Formik implementation with SPFx
 
 Open a command prompt\
 Move to the path where you want to create a project\
@@ -64,7 +64,7 @@ Create a project directory using:
 Move to the above-created directory using:
     cd react-formik
 Now execute the below command to create an SPFx solution:
-     yo @microsoft/sharepoint 
+     yo @microsoft/sharepoint
 It will ask some questions, as shown below,
 ![Project Setup.png](images/Project Setup.png)
 After a successful installation, we can open a project in any source
@@ -463,7 +463,7 @@ Now serve the application using the below command,
 Now test the webpart in SharePoint-SiteURL +
 /\_layouts/15/workbench.aspx.
 
-## Output 
+## Output
 
 ![SPFx-react-formik.gif](images/SPFx-react-formik.gif)
  

--- a/content/post/use-node-version-manager-to-develop-your-spfx-apps/index.md
+++ b/content/post/use-node-version-manager-to-develop-your-spfx-apps/index.md
@@ -4,9 +4,9 @@ date: 2021-02-14T08:40:00-04:00
 author: "Toni Pohl"
 githubname: tonipohl
 categories: ["Community post"]
-tags: ["SharePoint framework (SPFx)"]
+tags: ["SharePoint Framework (SPFx)"]
 type: "regular"
-images: 
+images:
 - images/p6.png
 summary: "To develop applications for SharePoint or Microsoft Teams with the SPFx framework, a few requirements must be met on your development computer. Learn how to install the supported Node.js v10.x version and how you can use other Node.js versions additionally with Node Version Manager"
 ---
@@ -18,7 +18,7 @@ to install the supported Node.js v10.x version and how you can use other
 Node.js versions additionally with Node Version
 Manager!
 
-## Why? 
+## Why?
 
 As developer, it often makes sense to have multiple versions of a
 framework installed on a single computer. For developing an app for
@@ -37,7 +37,7 @@ install NVM and desired Node.js versions, and how to switch between the
 Node.js versions. After the installation process, learn how to develop
 your custom SharePoint app using the provided tools.
 
-## Install nvm and Node.js 
+## Install nvm and Node.js
 
 First, follow the steps here to install the Node.js frameworks on your
 machine. Alternatively, there´s a good description at [Set up your
@@ -112,7 +112,7 @@ Etc. For the latest Node.js version, simply run
 nvm install latest
 ```
 
-Now check the installed versions: 
+Now check the installed versions:
 
 ```bash
 nvm ls
@@ -135,7 +135,7 @@ nvm use 14.15.4
 That´s the basic installation of Node.js and
 [npm](https://www.npmjs.com/get-npm).
 
-## Install the SPFx development tools once 
+## Install the SPFx development tools once
 
 To install the required tools
 [yo](https://docs.microsoft.com/sharepoint/dev/spfx/set-up-your-development-environment#install-yeoman)
@@ -155,7 +155,7 @@ npm install gulp yo @microsoft/generator-sharepoint --global
 
 ![npm install](images/p8.png)
 
-## Create a new SPFx web part 
+## Create a new SPFx web part
 
 To create a new SPFx app, follow the steps described at [Build your
 first SharePoint client-side web part (Hello World part
@@ -182,7 +182,7 @@ gulp trust-dev-cert
 
 You can open Visual Studio Code now to modify the solution: *code .*
 
-## Run the SPFx web part 
+## Run the SPFx web part
 
 The generated solution includes the sample app that can now be modified.
 
@@ -204,7 +204,7 @@ web part to the workbench page and test it.
 site and use the custom web part with the data from SharePoint, too:
 [https://\<tenant>.sharepoint.com/sites/\<sitename>/\_layouts/15/workbench.aspx](https://%3ctenant%3e.sharepoint.com/sites/%3Csitename%3E/_layouts/15/workbench.aspx)
 
-## Deploy the SPFx solution 
+## Deploy the SPFx solution
 
 To build the ready-to-use solution, run
 
@@ -222,7 +222,7 @@ to create the `\sharepoint\solution\<project>.sppkg` file that can
 be uploaded to the [SharePoint App
 catalog](https://docs.microsoft.com/sharepoint/use-app-catalog?redirectSourcePath=%252farticle%252fuse-the-app-catalog-to-make-custom-business-apps-available-for-your-sharepoint-online-environment-0b6ab336-8b83-423f-a06b-bcc52861cba0).
 
-## Develop the solution 
+## Develop the solution
 
 You can follow the next steps to develop the app described here:
 


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Related issues

- n/a

## Contents of the Pull Request

- previously there were three with different issues:
  - "SharePoint framework" < lcase 'F'
  - "SharePoint frameworks" < plural
  - "SPFx"
- this proposes to unify all to "SharePoint Framework (SPFx)"
