### PR TITLE
Optimize builds & responsive image generation

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -91,6 +91,7 @@ expire_days = 2
 [widgets]
 sidebar = ["categories", "tags", "recent-post", "social"]
 # available widget : search,about-me,authors,categories,tags,recent-post,social,promotion,subscription
+# do not use: about-me,authors (all widgets are cached so will be same across entire site)
 
 
 ############################# social site ########################

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,45 +1,38 @@
 {{ if findRE `^https?://` .Destination   }}
-        <img src="{{ .Destination | safeURL }}" {{ with .Text }} alt="{{ . }}" {{ end }} {{ with .Title }}
-            title="{{ . }}" {{ end }} style="width:auto;">
+  <img src="{{ .Destination | safeURL }}" style="width:auto;"{{ with .Text }} title="{{ . }}" alt="{{ . }}"{{ end }}>
 {{ else }}
-    {{ $image := .Page.Resources.GetMatch .Destination }}
-    {{ if $image }}
-        {{ $image_ext := path.Ext $image.RelPermalink }}
-        {{ $image_width := $image.Width }}
-        {{ if  (ne $image_ext ".gif") }}
-            {{ $tinyImage := $image.Resize "500x webp" }}
-            {{ $smallImage := $image.Resize "800x webp" }}
-            {{ $mediumImage := $image.Resize "1200x webp" }}
-            {{ $largeImage := $image.Resize "1500x webp" }}
-            
-            {{ if .Title }}
-            <figure>
-                <picture>
-                    <source media="(min-width:500px)" srcset={{ $smallImage.RelPermalink | safeURL }}>
-                    <source media="(min-width:800px)" srcset={{ $mediumImage.RelPermalink | safeURL }}>
-                    <source media="(min-width:1200px)" srcset={{ $largeImage.RelPermalink | safeURL }}>
-                    <source media="(min-width:1500px)" srcset={{ .Destination | safeURL }}>
-                    <img src="{{ $tinyImage.RelPermalink | safeURL }}" {{ with .Text }} alt="{{ . }}" {{ end }} {{ with .Title }}
-                        title="{{ . }}" {{ end }} style="width:auto;">
-                </picture>
-            
-                {{ with .Title}} <figcaption>{{ . | markdownify }}</figcaption> {{ end }}
-            </figure>
-            {{ else }}
-            <picture>
-                <source media="(min-width:500px)" srcset={{ $smallImage.RelPermalink | safeURL }}>
-                <source media="(min-width:800px)" srcset={{ $mediumImage.RelPermalink | safeURL }}>
-                <source media="(min-width:1200px)" srcset={{ $largeImage.RelPermalink | safeURL }}>
-                <source media="(min-width:1500px)" srcset={{ .Destination | safeURL }}>
-                <img src="{{ $tinyImage.RelPermalink | safeURL }}" {{ with .Text }} alt="{{ . }}" {{ end }} style="width:auto;">
-            </picture>
-            {{ end }}
-        {{ else }}
-            <img src="{{ $image.RelPermalink }}" {{ with .Text }} alt="{{ . }}" {{ end }} {{ with .Title }}
-                title="{{ . }}" {{ end }} style="width:auto;">
-        {{ end }}
+  {{ $image := .Page.Resources.GetMatch .Destination }}
+  {{ if $image }}
+    {{/*  if GIF, assume animated => don't resize*/}}
+    {{ if eq (path.Ext $image.RelPermalink) ".gif" }}
+      <img src="{{ $image.RelPermalink }}" style="width:auto;" {{ with .Text }} title="{{ . }}" alt="{{ . }}"{{ end }}>
+    {{/*  else, resize to responsive breakpoints  */}}
     {{ else }}
-        <img src="{{ .Destination | safeURL }}" {{ with .Text }} alt="{{ . }}" {{ end }} {{ with .Title }}
-            title="{{ . }}" {{ end }} style="width:auto;">
+      {{- $fallbackImage := $image.Resize "850x jpg" -}}
+      {{/*  supported responsive image dimensions  */}}
+      {{- $respSizes := slice "325" "675" -}}
+      {{- $sourceSizes := "(max-width: 400px) 325px, 675px" -}}
+      <figure>
+        <picture>
+          <source type="image/webp"
+                  srcset="{{- with $respSizes -}}
+                    {{- range $i, $e := . -}}
+                      {{- if ge $image.Width . -}}
+                        {{- if $i }}, {{ end -}}{{- ($image.Resize (printf "%sx%s" . " webp") ).RelPermalink }} {{ . }}w
+                      {{- end -}}
+                    {{- end -}}
+                  {{- end -}}"
+                  sizes="{{ $sourceSizes }}"
+          />
+          <img src="{{ $fallbackImage.RelPermalink | safeURL }}"
+               style="width:auto;" loading="lazy"
+               width="{{ $image.Width }}" height="{{ $image.Height }}"
+               {{ with .Text }} title="{{ . }}" alt="{{ . }}"{{ end }}>
+        </picture>
+        {{ with .Title }}<figcaption>{{ . | markdownify }}</figcaption> {{ end }}
+      </figure>
     {{ end }}
+  {{ else }}
+    <img src="{{ .Destination | safeURL }}" style="width:auto;" {{ with .Text }} title="{{ . }}" alt="{{ . }}"{{ end }}>
+  {{ end }}
 {{ end}}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,7 +1,13 @@
 {{ if findRE `^https?://` .Destination   }}
   <img src="{{ .Destination | safeURL }}" style="width:auto;"{{ with .Text }} title="{{ . }}" alt="{{ . }}"{{ end }}>
 {{ else }}
+  {{/*  try to get reference to image  */}}
   {{ $image := .Page.Resources.GetMatch .Destination }}
+
+  {{ if and (not $image) (hasPrefix .Destination "./") }}
+    {{ $image = .Page.Resources.Get (strings.TrimPrefix "./" .Destination) }}
+  {{ end }}
+
   {{ if $image }}
     {{/*  if GIF, assume animated => don't resize*/}}
     {{ if eq (path.Ext $image.RelPermalink) ".gif" }}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -8,27 +8,14 @@
       <img src="{{ $image.RelPermalink }}" style="width:auto;" {{ with .Text }} title="{{ . }}" alt="{{ . }}"{{ end }}>
     {{/*  else, resize to responsive breakpoints  */}}
     {{ else }}
-      {{- $fallbackImage := $image.Resize "850x jpg" -}}
-      {{/*  supported responsive image dimensions  */}}
-      {{- $respSizes := slice "325" "675" -}}
-      {{- $sourceSizes := "(max-width: 400px) 325px, 675px" -}}
       <figure>
-        <picture>
-          <source type="image/webp"
-                  srcset="{{- with $respSizes -}}
-                    {{- range $i, $e := . -}}
-                      {{- if ge $image.Width . -}}
-                        {{- if $i }}, {{ end -}}{{- ($image.Resize (printf "%sx%s" . " webp") ).RelPermalink }} {{ . }}w
-                      {{- end -}}
-                    {{- end -}}
-                  {{- end -}}"
-                  sizes="{{ $sourceSizes }}"
-          />
-          <img src="{{ $fallbackImage.RelPermalink | safeURL }}"
-               style="width:auto;" loading="lazy"
-               width="{{ $image.Width }}" height="{{ $image.Height }}"
-               {{ with .Text }} title="{{ . }}" alt="{{ . }}"{{ end }}>
-        </picture>
+        {{ partial "responsive-image" (dict
+              "image" $image
+              "imageSizes" (slice "325" "700")
+              "sourceSizes" "(max-width: 325px) 325px, 700px"
+              "altTitle" .Text
+            )
+        }}
         {{ with .Title }}<figcaption>{{ . | markdownify }}</figcaption> {{ end }}
       </figure>
     {{ end }}

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -11,7 +11,7 @@
       <figure>
         {{ partial "responsive-image" (dict
               "image" $image
-              "imageSizes" (slice "325" "700")
+              "resizeSizes" (slice "325" "700")
               "sourceSizes" "(max-width: 325px) 325px, 700px"
               "altTitle" .Text
             )

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,7 +18,7 @@
 
 <!-- regular page -->
 {{ else }}
-{{ partial "page-header.html" . }}
+{{ partialCached "page-header.html" . }}
 <section class="section-sm">
   <div class="container">
     <div class="row">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,160 +1,150 @@
 {{ define "main" }}
 
 <!-- checking blog -->
-{{ if or (eq .Section "post") (eq .Section "microsoft-viva-and-spfx-community-call") (eq .Section "cli-for-microsoft-365") (eq .Section "cli-for-microsoft-365") (eq .Section "m365-dev-podcast") (eq .Section "microsoft-365-developer-community-call")
-(eq .Section "categories") (eq .Section "tags") (eq .Section "adaptive-card-community-call") (eq .Section "power-platform-community-call") (eq .Section "microsoft-teams-community-call") (eq .Section "microsoft-365-platform-community-update") (eq .Section "microsoft-365-pnp-weekly") (eq .Section "m365-pnp-weekly") (eq .Section "adaptive-cards-community-call") (eq .Section "microsoft-365-pnp-community") (eq .Section "weekly-agenda") (eq .Section "office-add-ins-community-call") (eq .Section "microsoft-graph-community-call") (eq .Section "microsoft-identity-platform-community-call") (eq .Section "microsoft-365-platform-community-call") (eq .Section "pnp-powershell")}}
+{{ if or (eq .Section "post") (eq .Section "microsoft-viva-and-spfx-community-call") (eq .Section
+"cli-for-microsoft-365") (eq .Section "cli-for-microsoft-365") (eq .Section "m365-dev-podcast") (eq .Section
+"microsoft-365-developer-community-call")
+(eq .Section "categories") (eq .Section "tags") (eq .Section "adaptive-card-community-call") (eq .Section
+"power-platform-community-call") (eq .Section "microsoft-teams-community-call") (eq .Section
+"microsoft-365-platform-community-update") (eq .Section "microsoft-365-pnp-weekly") (eq .Section "m365-pnp-weekly") (eq
+.Section "adaptive-cards-community-call") (eq .Section "microsoft-365-pnp-community") (eq .Section "weekly-agenda") (eq
+.Section "office-add-ins-community-call") (eq .Section "microsoft-graph-community-call") (eq .Section
+"microsoft-identity-platform-community-call") (eq .Section "microsoft-365-platform-community-call") (eq .Section
+"pnp-powershell")}}
 
-{{ $sidebar:= site.Params.sidebar }}
-{{ $hasbar:= or (eq $sidebar `left`) (eq $sidebar `right`)}}
-{{ $layout:= site.Params.post_layout}}
-{{ $widget:= site.Params.widgets.sidebar }}
+  {{ $sidebar:= site.Params.sidebar }}
+  {{ $hasbar:= or (eq $sidebar `left`) (eq $sidebar `right`)}}
+  {{ $layout:= site.Params.post_layout}}
+  {{ $widget:= site.Params.widgets.sidebar }}
 
+  <div class="py-4"></div>
 
-
-<div class="py-4"></div>
-
-<section class="section">
+  <section class="section">
     <div class="container">
-        <div class="row">
-            <!-- left sidebar -->
-            {{ if eq $sidebar "left" }}
-            <aside class="col-lg-4 order-2 order-lg-1">
-                {{- partial "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) -}}
-            </aside>
-            {{ end }}
-            <!-- /left sidebar -->
+      <div class="row">
+        <!-- left sidebar -->
+        {{ if eq $sidebar "left" }}
+        <aside class="col-lg-4 order-2 order-lg-1">
+          {{- partialCached "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) -}}
+        </aside>
+        {{ end }}
+        <!-- /left sidebar -->
 
-            <div
-                class="{{if $hasbar}} col-lg-8 {{ else }} col-lg-10 mx-auto {{end}} {{if eq $sidebar `left`}} order-1 order-lg-2 {{end}} mb-5 mb-lg-0">
-                <article>
-                    {{ $resources:= .Resources }}
-                    <!-- post thumb -->
-                    {{ with .Params.images }}
-                    <div class="mb-4">
-                        {{ range first 1 .}}
-                        {{ $imgPath:= . }}
-                            {{ if findRE `^https?://` $imgPath }}
-                                <img src="{{ $imgPath | absURL }}" class="card-img" loading="lazy" alt="post-thumb">
-                            {{ else  if (and (hasPrefix $imgPath `images/blog/`) (fileExists (add `assets/` $imgPath))) }}
-                                {{ $image:= resources.Get $imgPath }}
-                                {{ $imageMD:= $image.Fill "700x330 webp" }}
-                                {{ $imageLG:= $image.Fill "510x240 webp" }}
-                                {{ $imageSM:= $image.Fill "380x180 webp" }}
-                                <picture>
-                                    <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 575px)">
-                                    <source srcset="{{ $imageMD.Permalink }}" media="(max-width: 767px)">
-                                    <source srcset="{{ $imageLG.Permalink }}" media="(max-width: 991px)">
-                                    <source srcset="{{$imageMD.Permalink}}">
-                                    <img src="{{$image.Permalink}}" class="card-img img-fluid" loading="lazy" alt="post-thumb"
-                                    max-width="{{$image.Width}}" max-height="{{$image.Height}}">
-                                </picture>
-                            {{ else }}
-                                {{ with $resources.GetMatch $imgPath }}
-                                {{ $image:= . }}
-                                {{ $imageMD:= $image.Fill "700x330 webp" }}
-                                {{ $imageLG:= $image.Fill "510x240 webp" }}
-                                {{ $imageSM:= $image.Fill "380x180 webp" }}
-                                <picture>
-                                    <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 575px)">
-                                    <source srcset="{{ $imageMD.Permalink }}" media="(max-width: 767px)">
-                                    <source srcset="{{ $imageLG.Permalink }}" media="(max-width: 991px)">
-                                    <source srcset="{{$imageMD.Permalink}}">
-                                    <img src="{{$image.Permalink}}" class="card-img img-fluid" loading="lazy" alt="post-thumb"
-                                    max-width="{{$image.Width}}" max-height="{{$image.Height}}">
-                                </picture>
-                                {{ else }}
-                                <img src="{{ . | absURL }}" class="card-img" loading="lazy" alt="post-thumb">
-                                {{ end }}
-                            {{ end }}
-                        {{ end }}
-                    </div>
-                    {{ end }}
-                    <!-- /post thumb -->
+        <div class="{{if $hasbar}} col-lg-8 {{ else }} col-lg-10 mx-auto {{end}} {{if eq $sidebar `left`}} order-1 order-lg-2 {{end}} mb-5 mb-lg-0">
+          <article>
+            <!-- post thumb -->
+            {{ $thumbnail := partial "get-featured-image" . }}
 
-                    <h1 class="h2">{{ .Title }}</h1>
-                    <ul class="card-meta my-3 list-inline">
-                        <li class="list-inline-item">
-                            {{ if .Params.githubname }}
-                            <a href="https://github.com/{{ .Params.githubname }}/" class="card-meta-author">
-                              <img loading="lazy" decoding="async" width="24" height="24" src="https://github.com/{{ .Params.githubname }}.png" alt="{{ .Params.githubname }}" class="img-fluid">
-                              <span>{{ .Params.author }}</span>
-                            </a>
-                            {{ else }}
-                            <span>{{ .Params.author }}</span>
-                            {{ end }}
-                        </li>
-                        <li class="list-inline-item">
-                            <i class="far fa-clock"></i>{{ .Page.ReadingTime }} {{ i18n "minute_read" }}
-                        </li>
-                        <li class="list-inline-item">
-                            <i class="far fa-calendar-alt"></i>{{ .PublishDate.Format "02 Jan, 2006" }}
-                        </li>
-                        <li class="list-inline-item">
-                            <ul class="card-meta-tag list-inline">
-                                {{ $filter:= site.Params.main_taxonomy }}
-                                {{ if eq $filter "tag" }}
-                                {{ $taxonomies := .Params.tags }}
-                                {{ range $taxonomies }}
-                                <li class="list-inline-item"><a
-                                        href="{{ `tags/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize }}</a>
-                                </li>
-                                {{ end }}
-                                {{ else if eq $filter "category" }}
-                                {{ $taxonomies := .Params.categories }}
-                                {{ range $taxonomies }}
-                                <li class="list-inline-item"><a
-                                        href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize
-                                        }}</a></li>
-                                {{ end }}
-                                {{ end }}
-                            </ul>
-                        </li>
-                        <li class="list-inline-item">
-                            <img src="https://api.visitorbadge.io/api/combined?path={{ .Permalink | safeURL }}&label=Views&labelColor=%23ffffff&countColor=%234c71d2&style=flat-square" title="Daily/total views" alt="Views (daily/total)" />
-                            </li>
-                    </ul>
-                    <div class="content">{{ .Content }}</div>
-                </article>
-                <!-- comments -->
-                {{ if site.DisqusShortname }}
-                <div class="mt-5 border-default border p-4 bg-white">
-                    {{ template "_internal/disqus.html" . }}
+            {{ if $thumbnail }}
+              {{- $fallbackImage := $thumbnail.Resize "700x jpg" -}}
+              {{/*  supported responsive image dimensions  */}}
+              {{- $respSizes := slice "400" "700" -}}
+              {{- $sourceSizes := "(max-width: 400px) 400px, 700px" -}}
+              <div class="mb-4">
+                <picture>
+                  <source type="image/webp"
+                          srcset="{{- with $respSizes -}}
+                            {{- range $i, $e := . -}}
+                              {{- if ge $thumbnail.Width . -}}
+                                {{- if $i }}, {{ end -}}{{- ($thumbnail.Resize (printf "%sx%s" . " webp") ).RelPermalink }} {{ . }}w
+                              {{- end -}}
+                            {{- end -}}
+                          {{- end -}}"
+                          sizes="{{ $sourceSizes }}"
+                  />
+                  <img src="{{ $fallbackImage.RelPermalink | safeURL }}"
+                       style="width:auto;" loading="lazy"
+                       {{ with .Title }} title="{{ . }}" alt="{{ . }}"{{ end }}>
+                </picture>
+              </div>
+            {{ else }}
+              {{ with .Params.images }}
+                {{/*  use string path to image  */}}
+                <div class="mb-4">
+                  <img src="{{ (index . 0) | absURL }}" class="card-img" loading="lazy" alt="post-thumb">
                 </div>
+              {{ end }}
+            {{ end }}
+            <!-- /post thumb -->
+
+            <h1 class="h2">{{ .Title }}</h1>
+            <ul class="card-meta my-3 list-inline">
+              <li class="list-inline-item">
+                {{ if .Params.githubname }}
+                  <a href="https://github.com/{{ .Params.githubname }}/" class="card-meta-author">
+                    <img loading="lazy" decoding="async" width="24" height="24" src="https://github.com/{{ .Params.githubname }}.png" alt="{{ .Params.githubname }}" class="img-fluid">
+                    <span>{{ .Params.author }}</span>
+                  </a>
+                {{ else }}
+                  <span>{{ .Params.author }}</span>
                 {{ end }}
-                <script src="https://utteranc.es/client.js"
-                repo="pnp/blog"
-                issue-term="title"
-                theme="github-light"
-                crossorigin="anonymous"
-                async>
-        </script>
+              </li>
+              <li class="list-inline-item">
+                <i class="far fa-clock"></i>{{ .Page.ReadingTime }} {{ i18n "minute_read" }}
+              </li>
+              <li class="list-inline-item">
+                <i class="far fa-calendar-alt"></i>{{ .PublishDate.Format "02 Jan, 2006" }}
+              </li>
+              <li class="list-inline-item">
+                <ul class="card-meta-tag list-inline">
+                  {{ $filter:= site.Params.main_taxonomy }}
+                  {{ if eq $filter "tag" }}
+                    {{ range .Params.tags }}
+                      <li class="list-inline-item">
+                        <a href="{{ `tags/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize }}</a>
+                      </li>
+                    {{ end }}
+                  {{ else if eq $filter "category" }}
+                    {{ range .Params.categories }}
+                      <li class="list-inline-item">
+                        <a href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize }}</a>
+                      </li>
+                    {{ end }}
+                  {{ end }}
+                </ul>
+              </li>
+              <li class="list-inline-item">
+                <img src="https://api.visitorbadge.io/api/combined?path={{ .Permalink | safeURL }}&label=Views&labelColor=%23ffffff&countColor=%234c71d2&style=flat-square" title="Daily/total views" alt="Views (daily/total)" />
+              </li>
+            </ul>
+            <div class="content">
+              {{ .Content }}
             </div>
-
-            <!-- right sidebar -->
-            {{ if eq $sidebar "right" }}
-            <aside class="col-lg-4">
-                {{- partial "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) -}}
-            </aside>
-            {{ end }}
-            <!-- /right sidebar -->
+          </article>
+          <!-- comments -->
+          {{ if site.DisqusShortname }}
+            <div class="mt-5 border-default border p-4 bg-white">
+              {{ template "_internal/disqus.html" . }}
+            </div>
+          {{ end }}
+          <script src="https://utteranc.es/client.js" repo="pnp/blog" issue-term="title" theme="github-light" crossorigin="anonymous" async></script>
         </div>
-    </div>
-</section>
 
-<!-- regular page -->
+        <!-- right sidebar -->
+        {{ if eq $sidebar "right" }}
+        <aside class="col-lg-4">
+          {{- partialCached "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) -}}
+        </aside>
+        {{ end }}
+        <!-- /right sidebar -->
+      </div>
+    </div>
+  </section>
+
+  <!-- regular page -->
 {{ else }}
-{{ partial "page-header.html" . }}
-<section class="section-sm">
+  {{ partialCached "page-header.html" . }}
+  <section class="section-sm">
     <div class="container">
-        <div class="row">
-            <div class="col-lg-10 mx-auto">
-                <div class="content">
-                    {{.Content}}
-                </div>
-            </div>
+      <div class="row">
+        <div class="col-lg-10 mx-auto">
+          <div class="content">
+            {{.Content}}
+          </div>
         </div>
+      </div>
     </div>
-</section>
+  </section>
 {{ end }}
 <!-- /regular page -->
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,26 +36,14 @@
             {{ $thumbnail := partial "get-featured-image" . }}
 
             {{ if $thumbnail }}
-              {{- $fallbackImage := $thumbnail.Resize "700x jpg" -}}
-              {{/*  supported responsive image dimensions  */}}
-              {{- $respSizes := slice "400" "700" -}}
-              {{- $sourceSizes := "(max-width: 400px) 400px, 700px" -}}
               <div class="mb-4">
-                <picture>
-                  <source type="image/webp"
-                          srcset="{{- with $respSizes -}}
-                            {{- range $i, $e := . -}}
-                              {{- if ge $thumbnail.Width . -}}
-                                {{- if $i }}, {{ end -}}{{- ($thumbnail.Resize (printf "%sx%s" . " webp") ).RelPermalink }} {{ . }}w
-                              {{- end -}}
-                            {{- end -}}
-                          {{- end -}}"
-                          sizes="{{ $sourceSizes }}"
-                  />
-                  <img src="{{ $fallbackImage.RelPermalink | safeURL }}"
-                       style="width:auto;" loading="lazy"
-                       {{ with .Title }} title="{{ . }}" alt="{{ . }}"{{ end }}>
-                </picture>
+                {{ partial "responsive-image" (dict
+                     "image" $thumbnail
+                     "imageSizes" (slice "400" "700")
+                     "sourceSizes" "(max-width: 400px) 400px, 700px"
+                     "altTitle" .Title
+                   )
+                }}
               </div>
             {{ else }}
               {{ with .Params.images }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,7 +39,7 @@
               <div class="mb-4">
                 {{ partial "responsive-image" (dict
                      "image" $thumbnail
-                     "imageSizes" (slice "400" "700")
+                     "resizeSizes" (slice "400" "700")
                      "sourceSizes" "(max-width: 400px) 400px, 700px"
                      "altTitle" .Title
                    )

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -97,54 +97,24 @@
         <h2 class="h5 section-title">{{ i18n "editors_pick" }}</h2>
         {{ range first 1 (where site.RegularPages "Type" "epic")}}
         <article class="card">
-                    {{ $resources:= .Resources }}
           <!-- post thumb -->
-          {{ if .Params.images }}
-
-          <div class="post-slider slider-sm">
-            <a href="{{ .Permalink }}">
-            {{ range .Params.images }}
-              {{ $imgPath:= . }}
-              
-                {{ if (and (hasPrefix $imgPath `images/blog/`) (fileExists (add `assets/` $imgPath))) }}
-                  {{ $img:= resources.Get $imgPath }}
-                  {{ $imageLG:= $img.Fill "700x330 webp" }}
-                  {{ $imageMD:= $img.Fill "510x240 webp" }}
-                  {{ $imageSM:= $img.Fill "380x180 webp" }}
-                  <picture>
-                    <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
-                    <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
-                    <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
-                    <source srcset="{{$imageSM.RelPermalink}}">
-                    <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb"
-                      width="{{$img.Width}}" height="{{$img.Height}}">
-                  </picture>
-                {{ else }}
-                  {{ with $resources.GetMatch $imgPath }}
-                    {{ $img:= . }}
-                    {{ $imageLG:= $img.Fill "700x330 webp" }}
-                    {{ $imageMD:= $img.Fill "510x240 webp" }}
-                    {{ $imageSM:= $img.Fill "380x180 webp" }}
-                    <picture>
-                      <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
-                      <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
-                      <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
-                      <source srcset="{{$imageSM.RelPermalink}}">
-                      <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb"
-                        width="{{$img.Width}}" height="{{$img.Height}}">
-                    </picture>
-                  {{ else }}
-                    <div class="image-fallback"><span>{{ .Title | truncate 1}}</span></div>
-                  {{ end }}
-                {{ end }}
-            {{ end }} 
-            </a>
-          </div>
-          {{ else }}
-            <div class="image-fallback"><span>{{.Title | truncate 1}}</span></div>
+          {{ $thumbnail := partial "get-featured-image" . }}
+          {{ if $thumbnail }}
+            <div class="post-slider slider-sm">
+              <a href="{{ .Permalink }}">
+                {{ partial "responsive-image" (dict
+                    "image" $thumbnail
+                    "fillSizes" (slice "380x180" "700x330")
+                    "sourceSizes" "(max-width: 575px) 380px, 700px"
+                    "altTitle" .Title
+                    "cssImgOverride" "card-img-top img-fluid"
+                  )
+                }}
+              </a>
+            </div>
           {{ end }}
-
           <!-- /post thumb -->
+
           <div class="card-body">
             <h3 class="h4 mb-3"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h3>
             <ul class="card-meta list-inline">
@@ -187,38 +157,28 @@
         </article>
         {{ end }}
       </div>
+
       <!-- trending post -->
       <div class="col-lg-4 col-md-6 mb-5">
         <h2 class="h5 section-title">{{ i18n "trending_post" }}</h2>
         {{ range first 3 (where site.RegularPages "Type" "trending")}}
         <article class="card mb-4">
           <div class="card-body d-flex">
-                    {{ $resources:= .Resources }}
-
             <!-- post thumb -->
-            {{ if .Params.images }}
-            <a href="{{ .Permalink }}">
-              {{ range first 1 .Params.images }}
-              {{ $imgPath:= . }}
-              {{ if fileExists (add `assets/` $imgPath) }}
-                {{ $img:= resources.Get $imgPath }}
-                {{ $imageXS:= $img.Fill "85x85 webp" }}
-                <img loading="lazy" decoding="async" width="{{$img.Width}}" height="{{$img.Height}}" src="{{$imageXS.RelPermalink}}" class="card-img-sm" loading="lazy" alt="post-thumb">
-              {{ else }}
-                {{ with $resources.GetMatch $imgPath }}
-                  {{ $img:= . }}
-                  {{ $imageXS:= $img.Fill "85x85 webp" }}
-                  <img loading="lazy" decoding="async" width="{{$img.Width}}" height="{{$img.Height}}" src="{{$imageXS.RelPermalink}}"
-                    class="card-img-sm" loading="lazy" alt="post-thumb">
-                {{ else }}
-                  <div class="image-fallback"><span>{{ .Title | truncate 1}}</span></div>
-                {{ end }}
-              {{ end }}</a>
-              {{ end }}
-            {{ else }}
-              <div class="image-fallback-sm"><span>{{.Title | truncate 1}}</span></div>
+            {{ $thumbnail := partial "get-featured-image" . }}
+            {{ if $thumbnail }}
+              <a href="{{ .Permalink }}">
+                {{ partial "responsive-image" (dict
+                    "image" $thumbnail
+                    "fillSizes" (slice "85x85")
+                    "altTitle" .Title
+                    "cssImgOverride" "card-img-sm"
+                  )
+                }}
+              </a>
             {{ end }}
             <!-- /post thumb -->
+
             <div class="ml-3">
               <h4><a href="{{.Permalink}}" class="post-title">{{ .Title }}</a></h4>
               <ul class="card-meta list-inline mb-0">
@@ -234,52 +194,27 @@
         </article>
         {{ end }}
       </div>
+
       <!-- popular post -->
       <div class="col-lg-4 mb-5">
         <h2 class="h5 section-title">{{ i18n "popular_post" }}</h2>
         {{ range first 1 (where site.RegularPages "Type" "popular")}}
         <article class="card">
-          {{ $resources:= .Resources }}
           <!-- post thumb -->
-          {{ if .Params.images }}
-          <div class="post-slider slider-sm">
-            <a href="{{ .Permalink }}">
-            {{ range .Params.images }}
-              {{ $imgPath:= . }}
-              {{ if fileExists (add `assets/` .) }}
-                {{ $img:= resources.Get . }}
-                {{ $imageLG:= $img.Fill "700x330 webp" }}
-                {{ $imageMD:= $img.Fill "510x240 webp" }}
-                {{ $imageSM:= $img.Fill "380x180 webp" }}
-                <picture>
-                  <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
-                  <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
-                  <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
-                  <source srcset="{{$imageSM.RelPermalink}}">
-                  <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid"  alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-                </picture>
-              {{ else }}
-              {{ with $resources.GetMatch $imgPath }}
-                {{ $img:= . }}
-                {{ $imageLG:= $img.Fill "700x330 webp" }}
-                {{ $imageMD:= $img.Fill "510x240 webp" }}
-                {{ $imageSM:= $img.Fill "380x180 webp" }}
-                <picture>
-                  <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
-                  <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
-                  <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
-                  <source srcset="{{$imageSM.RelPermalink}}">
-                  <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb"
-                    width="{{$img.Width}}" height="{{$img.Height}}">
-                </picture>
-              {{ else }}
-                <div class="image-fallback"><span>{{.Title | truncate 1}}</span></div>
-              {{ end }}
-              {{ end }}
-            {{ end }}</a>
-          </div>
-          {{ else }}
-            <div class="image-fallback"><span>{{.Title | truncate 1}}</span></div>
+          {{ $thumbnail := partial "get-featured-image" . }}
+          {{ if $thumbnail }}
+            <div class="post-slider slider-sm">
+              <a href="{{ .Permalink }}">
+                {{ partial "responsive-image" (dict
+                    "image" $thumbnail
+                    "fillSizes" (slice "380x180" "700x330")
+                    "sourceSizes" "(max-width: 575px) 380px, 700px"
+                    "altTitle" .Title
+                    "cssImgOverride" "card-img-top img-fluid"
+                  )
+                }}
+              </a>
+            </div>
           {{ end }}
           <!-- /post thumb -->
           <div class="card-body">

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -8,187 +8,267 @@
   <div class="row">
     <!-- left sidebar -->
     {{ if eq $sidebar "left" }}
-    <aside class="col-lg-4 order-2 order-lg-1 {{.Scratch.Get `sidebar-margin`}}">
-      {{- partial "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) -}}
-    </aside>
+      <aside class="col-lg-4 order-2 order-lg-1 {{.Scratch.Get `sidebar-margin`}}">
+        {{- partialCached "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) -}}
+      </aside>
     {{ end }}
     <!-- /left sidebar -->
 
-    <div
-      class="{{if $hasbar}}col-lg-8{{ else }}{{if eq $layout `grid` }} col-12 {{else}} col-lg-8 mx-auto {{end}}{{end}} {{if eq $sidebar `left`}}order-1 order-lg-2{{end}} mb-5 mb-lg-0">
+    <div class="{{if $hasbar}}col-lg-8{{ else }}{{if eq $layout `grid` }} col-12 {{else}} col-lg-8 mx-auto {{end}}{{end}} {{if eq $sidebar `left`}}order-1 order-lg-2{{end}} mb-5 mb-lg-0">
 
       <!-- wrapper title -->
       {{ if eq (.Scratch.Get "title") "taxonomies"}}
-      <h1 class="h2 mb-5">{{i18n `showing_from`}} <mark>{{ .Title }}</mark></h1>
-      {{else if eq (.Scratch.Get "title") "recent"}}
-      <h2 class="h5 section-title">{{ i18n "recent_post" }}</h2>
+        <h1 class="h2 mb-5">{{i18n `showing_from`}} <mark>{{ .Title }}</mark></h1>
+      {{ else if eq (.Scratch.Get "title") "recent" }}
+        <h2 class="h5 section-title">{{ i18n "recent_post" }}</h2>
       {{ end }}
       <!-- /wrapper title -->
 
       {{ if eq $layout "list" }}
-      {{ range $paginator.Pages }}
-      <!-- list article -->
-      <article class="card mb-4">
-        <div class="row card-body">
-          {{ $resources:= .Resources }}
-          <!-- post thumb -->
-          <div class="col-md-4 mb-4 mb-md-0">
-            {{ if .Params.images }}
-            <div class="post-slider slider-sm">
-              <a href="{{ .Permalink }}">
-              {{ range .Params.images }}
-              {{ $imgPath:= . }}
-              {{ if fileExists (add `assets/` $imgPath) }}
-              {{ $img:= resources.Get $imgPath }}
-              {{ $imageSM:= $img.Fill "460x200 webp" }}
-              {{ $imageXS:= $img.Fill "200x200 webp" }}
-              <picture>
-                <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 767px)">
-                <source srcset="{{ $imageXS.Permalink }}" media="(min-width: 768px)">
-                <source srcset="{{$img.RelPermalink}}">
-                <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid"
-                  alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-              </picture>
-              {{ else }}
-              {{ with $resources.GetMatch $imgPath }}
-              {{ $img:= . }}
-              {{ $imageSM:= $img.Fill "460x200 webp" }}
-              {{ $imageXS:= $img.Fill "200x200 webp" }}
-              <picture>
-                <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 767px)">
-                <source srcset="{{ $imageXS.Permalink }}" media="(min-width: 768px)">
-                <source srcset="{{$img.RelPermalink}}">
-                <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb"
-                  width="{{$img.Width}}" height="{{$img.Height}}">
-              </picture>
-              {{ else }}
-              <div class="image-fallback"><span>{{.Title | truncate 1}}</span></div>
-              {{ end }}
-              {{ end }}
-              {{ end }}</a>
-            </div>
-            {{ else }}
-            <div class="image-fallback"><span>{{.Title | truncate 1}}</span></div>
-            {{ end }}
-          </div>
-          <!-- /post thumb -->
-          <div class="col-md-8">
-            <h3 class="h4 mb-3"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h3>
-            <ul class="card-meta list-inline">
-              <li class="list-inline-item">
-                {{ if .Params.githubname }}
-                <a href="https://github.com/{{ .Params.githubname }}/" class="card-meta-author">
-                  <img loading="lazy" decoding="async" width="24" height="24"
-                    src="https://github.com/{{ .Params.githubname }}.png" alt="{{ .Params.githubname }}"
-                    class="img-fluid">
-                  <span>{{ .Params.author }}</span>
-                </a>
+
+        {{ range $paginator.Pages }}
+          <!-- list article -->
+          <article class="card mb-4">
+            <div class="row card-body">
+              {{ $resources:= .Resources }}
+              <!-- post thumb -->
+              <div class="col-md-4 mb-4 mb-md-0">
+                {{ if .Params.images }}
+                  <div class="post-slider slider-sm">
+                    <a href="{{ .Permalink }}">
+                      {{ range .Params.images }}
+                        {{ $imgPath:= . }}
+                        {{ if fileExists (add `assets/` $imgPath) }}
+                          {{ $img:= resources.Get $imgPath }}
+                          {{ $imageSM:= $img.Fill "460x200 webp" }}
+                          {{ $imageXS:= $img.Fill "200x200 webp" }}
+                          <picture>
+                            <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 767px)">
+                            <source srcset="{{ $imageXS.Permalink }}" media="(min-width: 768px)">
+                            <source srcset="{{$img.RelPermalink}}">
+                            <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
+                          </picture>
+                        {{ else }}
+                          {{ with $resources.GetMatch $imgPath }}
+                            {{ $img:= . }}
+                            {{ $imageSM:= $img.Fill "460x200 webp" }}
+                            {{ $imageXS:= $img.Fill "200x200 webp" }}
+                            <picture>
+                              <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 767px)">
+                              <source srcset="{{ $imageXS.Permalink }}" media="(min-width: 768px)">
+                              <source srcset="{{$img.RelPermalink}}">
+                              <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
+                            </picture>
+                          {{ else }}
+                            <div class="image-fallback"><span>{{.Title | truncate 1}}</span></div>
+                          {{ end }}
+                        {{ end }}
+                      {{ end }}
+                    </a>
+                  </div>
                 {{ else }}
-                <span>{{ .Params.author }}</span>
+                  <div class="image-fallback"><span>{{.Title | truncate 1}}</span></div>
                 {{ end }}
-              </li>
-              <li class="list-inline-item">
-                <i class="far fa-clock"></i>{{ .Page.ReadingTime }} {{ i18n "minute_read" }}
-              </li>
-              <li class="list-inline-item">
-                <i class="far fa-calendar-alt"></i>{{ .PublishDate.Format "02 Jan, 2006" }}
-              </li>
-              <li class="list-inline-item">
-                <ul class="card-meta-tag list-inline">
-                  {{ $filter:= site.Params.main_taxonomy }}
-                  {{ if eq $filter "tag" }}
-                  {{ $taxonomies := .Params.tags }}
-                  {{ range $taxonomies }}
-                  <li class="list-inline-item"><a href="{{ `tags/` | relLangURL }}{{ . | urlize | lower }}">{{ . |
-                      humanize }}</a></li>
-                  {{ end }}
-                  {{ else if eq $filter "category" }}
-                  {{ $taxonomies := .Params.categories }}
-                  {{ range $taxonomies }}
-                  <li class="list-inline-item"><a href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}">{{ . |
-                      humanize }}</a></li>
-                  {{ end }}
-                  {{ end }}
+              </div>
+              <!-- /post thumb -->
+              <div class="col-md-8">
+                <h3 class="h4 mb-3"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h3>
+                <ul class="card-meta list-inline">
+                  <li class="list-inline-item">
+                    {{ if .Params.githubname }}
+                      <a href="https://github.com/{{ .Params.githubname }}/" class="card-meta-author">
+                        <img loading="lazy" decoding="async" width="24" height="24" src="https://github.com/{{ .Params.githubname }}.png" alt="{{ .Params.githubname }}" class="img-fluid">
+                        <span>{{ .Params.author }}</span>
+                      </a>
+                    {{ else }}
+                      <span>{{ .Params.author }}</span>
+                    {{ end }}
+                  </li>
+                  <li class="list-inline-item">
+                    <i class="far fa-clock"></i>{{ .Page.ReadingTime }} {{ i18n "minute_read" }}
+                  </li>
+                  <li class="list-inline-item">
+                    <i class="far fa-calendar-alt"></i>{{ .PublishDate.Format "02 Jan, 2006" }}
+                  </li>
+                  <li class="list-inline-item">
+                    <ul class="card-meta-tag list-inline">
+                      {{ $filter:= site.Params.main_taxonomy }}
+                      {{ if eq $filter "tag" }}
+                        {{ range .Params.tags }}
+                          <li class="list-inline-item">
+                            <a href="{{ `tags/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize }}</a>
+                          </li>
+                        {{ end }}
+                      {{ else if eq $filter "category" }}
+                        {{ range .Params.categories }}
+                          <li class="list-inline-item">
+                            <a href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize }}</a>
+                          </li>
+                        {{ end }}
+                      {{ end }}
+                    </ul>
+                  </li>
                 </ul>
-              </li>
-            </ul>
-            <p>
-              {{ if .Params.Images }}
-              {{ .Summary | truncate 100 }}
-              {{ else }}
-              {{ .Summary | truncate 250 }}
-              {{ end }}
-            </p>
-            <a href="{{.Permalink}}" class="btn btn-outline-primary">{{i18n "read_more"}}</a>
-          </div>
-        </div>
-      </article>
-      <!-- /list article -->
-      {{ end }}
+                <p>
+                  {{ if .Params.Images }}
+                    {{ .Summary | truncate 100 }}
+                  {{ else }}
+                    {{ .Summary | truncate 250 }}
+                  {{ end }}
+                </p>
+                <a href="{{.Permalink}}" class="btn btn-outline-primary">{{i18n "read_more"}}</a>
+              </div>
+            </div>
+          </article>
+          <!-- /list article -->
+        {{ end }}
 
       {{ else if eq $layout "grid" }}
-      <!-- grid article -->
-      <div class="row">
+
+        <!-- grid article -->
+        <div class="row">
+          {{ range $paginator.Pages }}
+            <div class="{{if $hasbar}}col-md-6{{else}}col-lg-4 col-md-6{{end}} mb-4">
+              <article class="card h-100">
+                {{ $resources:= .Resources }}
+                <!-- post thumb -->
+                {{ if .Params.images }}
+                  <div class="post-slider slider-sm">
+                    <a href="{{ .Permalink }}">
+                      {{ range .Params.images }}
+                        {{ $imgPath:= . }}
+                        {{ if fileExists (add `assets/` $imgPath) }}
+                          {{ $img:= resources.Get $imgPath }}
+                          {{ $imageLG:= $img.Fill "700x330 webp" }}
+                          {{ $imageMD:= $img.Fill "510x240 webp" }}
+                          {{ $imageSM:= $img.Fill "380x180 webp" }}
+                          <picture>
+                            <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
+                            <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
+                            <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
+                            <source srcset="{{$imageSM.RelPermalink}}">
+                            <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
+                          </picture>
+                        {{ else }}
+                          {{ with $resources.GetMatch $imgPath }}
+                            {{ $img:= . }}
+                            {{ $imageLG:= $img.Fill "700x330 webp" }}
+                            {{ $imageMD:= $img.Fill "510x240 webp" }}
+                            {{ $imageSM:= $img.Fill "380x180 webp" }}
+                            <picture>
+                              <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
+                              <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
+                              <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
+                              <source srcset="{{$imageSM.RelPermalink}}">
+                              <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
+                            </picture>
+                          {{ else }}
+                            <div class="image-fallback h-auto"><span>{{.Title | truncate 1}}</span></div>
+                          {{ end }}
+                        {{ end }}
+                      {{ end }}
+                    </a>
+                  </div>
+                {{ else }}
+                  <div class="image-fallback h-auto"><span>{{.Title | truncate 1}}</span></div>
+                {{ end }}
+                <!-- /post thumb -->
+                <div class="card-body">
+                  <h3 class="h4 mb-3"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h3>
+                  <ul class="card-meta list-inline">
+                    <li class="list-inline-item">
+                      {{ if .Params.githubname }}
+                        <a href="https://github.com/{{ .Params.githubname }}/" class="card-meta-author">
+                          <img loading="lazy" decoding="async" width="24" height="24" src="https://github.com/{{ .Params.githubname }}.png" alt="{{ .Params.githubname }}" class="img-fluid">
+                          <span>{{ .Params.author }}</span>
+                        </a>
+                      {{ else }}
+                        <span>{{ .Params.author }}</span>
+                      {{ end }}
+                    </li>
+                    <li class="list-inline-item">
+                      <i class="far fa-clock"></i>{{ .Page.ReadingTime }} {{ i18n "minute_read" }}
+                    </li>
+                    <li class="list-inline-item">
+                      <i class="far fa-calendar-alt"></i>{{ .PublishDate.Format "02 Jan, 2006" }}
+                    </li>
+                    <li class="list-inline-item">
+                      <ul class="card-meta-tag list-inline">
+                        {{ $filter:= site.Params.main_taxonomy }}
+                        {{ if eq $filter "tag" }}
+                          {{ range .Params.tags }}
+                            <li class="list-inline-item">
+                              <a href="{{ `tags/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize }}</a>
+                            </li>
+                          {{ end }}
+                        {{ else if eq $filter "category" }}
+                          {{ range .Params.categories }}
+                            <li class="list-inline-item">
+                              <a href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize }}</a>
+                            </li>
+                          {{ end }}
+                        {{ end }}
+                      </ul>
+                    </li>
+                  </ul>
+                  <p>{{ .Summary | truncate 80 }}</p>
+                  <a href="{{.Permalink}}" class="btn btn-outline-primary">{{i18n "read_more"}}</a>
+                </div>
+              </article>
+            </div>
+          {{ end }}
+        </div>
+        <!-- grid article -->
+
+      {{ else }}
         {{ range $paginator.Pages }}
-        <div class="{{if $hasbar}}col-md-6{{else}}col-lg-4 col-md-6{{end}} mb-4">
-          <article class="card h-100">
+          <!-- full article -->
+          <article class="card mb-4">
             {{ $resources:= .Resources }}
             <!-- post thumb -->
             {{ if .Params.images }}
-            <div class="post-slider slider-sm">
-              <a href="{{ .Permalink }}">
-              {{ range .Params.images }}
-              {{ $imgPath:= . }}
-              {{ if fileExists (add `assets/` $imgPath) }}
-              {{ $img:= resources.Get $imgPath }}
-              {{ $imageLG:= $img.Fill "700x330 webp" }}
-              {{ $imageMD:= $img.Fill "510x240 webp" }}
-              {{ $imageSM:= $img.Fill "380x180 webp" }}
-              <picture>
-                <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
-                <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
-                <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
-                <source srcset="{{$imageSM.RelPermalink}}">
-                <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid"
-                  alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-              </picture>
-              {{ else }}
-              {{ with $resources.GetMatch $imgPath }}
-              {{ $img:= . }}
-{{ $imageLG:= $img.Fill "700x330 webp" }}
-{{ $imageMD:= $img.Fill "510x240 webp" }}
-{{ $imageSM:= $img.Fill "380x180 webp" }}
-<picture>
-  <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
-  <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
-  <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
-  <source srcset="{{$imageSM.RelPermalink}}">
-  <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb"
-    width="{{$img.Width}}" height="{{$img.Height}}">
-</picture>
-{{ else }}
-              <div class="image-fallback h-auto"><span>{{.Title | truncate 1}}</span></div>
-              {{ end }}
-              {{ end }}
-              {{ end }}</a>
-            </div>
-            {{ else }}
-            <div class="image-fallback h-auto"><span>{{.Title | truncate 1}}</span></div>
+              <div class="post-slider slider-sm">
+                <a href="{{ .Permalink }}">
+                  {{ range .Params.images }}
+                    {{ $imgPath:= . }}
+                    {{ if fileExists (add `assets/` $imgPath) }}
+                      {{ $img:= resources.Get $imgPath }}
+                      {{ $imageMD:= $img.Fill "700x330 webp" }}
+                      {{ $imageSM:= $img.Fill "380x180 webp" }}
+                      <picture>
+                        <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 575px)">
+                        <source srcset="{{ $imageMD.Permalink }}" media="(max-width: 991px)">
+                        <img loading="lazy" decoding="async" src="{{$imageMD.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
+                      </picture>
+                    {{ else }}
+                      {{ with $resources.GetMatch $imgPath }}
+                        {{ $img:= . }}
+                        {{ $imageMD:= $img.Fill "700x330 webp" }}
+                        {{ $imageSM:= $img.Fill "380x180 webp" }}
+                        <picture>
+                          <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 575px)">
+                          <source srcset="{{ $imageMD.Permalink }}" media="(max-width: 991px)">
+                          <img loading="lazy" decoding="async" src="{{$imageMD.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
+                        </picture>
+                      {{ end }}
+                    {{ end }}
+                  {{ end }}
+                </a>
+              </div>
             {{ end }}
             <!-- /post thumb -->
+
             <div class="card-body">
-              <h3 class="h4 mb-3"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h3>
+              <h3 class="mb-3"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h3>
               <ul class="card-meta list-inline">
                 <li class="list-inline-item">
                   {{ if .Params.githubname }}
-                  <a href="https://github.com/{{ .Params.githubname }}/" class="card-meta-author">
-                    <img loading="lazy" decoding="async" width="24" height="24"
-                      src="https://github.com/{{ .Params.githubname }}.png" alt="{{ .Params.githubname }}"
-                      class="img-fluid">
-                    <span>{{ .Params.author }}</span>
-                  </a>
+                    <a href="https://github.com/{{ .Params.githubname }}/" class="card-meta-author">
+                      <img loading="lazy" decoding="async" width="24" height="24" src="https://github.com/{{ .Params.githubname }}.png" alt="{{ .Params.githubname }}" class="img-fluid">
+                      <span>{{ .Params.author }}</span>
+                    </a>
                   {{ else }}
-                  <span>{{ .Params.author }}</span>
+                    <span>{{ .Params.author }}</span>
                   {{ end }}
                 </li>
                 <li class="list-inline-item">
@@ -201,115 +281,27 @@
                   <ul class="card-meta-tag list-inline">
                     {{ $filter:= site.Params.main_taxonomy }}
                     {{ if eq $filter "tag" }}
-                    {{ $taxonomies := .Params.tags }}
-                    {{ range $taxonomies }}
-                    <li class="list-inline-item"><a href="{{ `tags/` | relLangURL }}{{ . | urlize | lower }}">{{ . |
-                        humanize }}</a></li>
-                    {{ end }}
+                      {{ range .Params.tags }}
+                        <li class="list-inline-item">
+                          <a href="{{ `tags/` | relLangURL }}{{ . | urlize | lower }}">{{ . | humanize }}</a>
+                        </li>
+                      {{ end }}
                     {{ else if eq $filter "category" }}
-                    {{ $taxonomies := .Params.categories }}
-                    {{ range $taxonomies }}
-                    <li class="list-inline-item"><a href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}">{{ .
-                        | humanize }}</a></li>
-                    {{ end }}
+                      {{ range .Params.categories }}
+                        <li class="list-inline-item">
+                          <a href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}">{{ . |humanize }}</a>
+                        </li>
+                      {{ end }}
                     {{ end }}
                   </ul>
                 </li>
               </ul>
-              <p>{{ .Summary | truncate 80 }}</p>
+              <p>{{ .Summary }}</p>
               <a href="{{.Permalink}}" class="btn btn-outline-primary">{{i18n "read_more"}}</a>
             </div>
           </article>
-        </div>
+          <!-- /full article -->
         {{ end }}
-      </div>
-      <!-- grid article -->
-
-      {{ else }}
-      {{ range $paginator.Pages }}
-      <!-- full article -->
-      <article class="card mb-4">
-                    {{ $resources:= .Resources }}
-        <!-- post thumb -->
-        {{ if .Params.images }}
-        <div class="post-slider slider-sm">
-          <a href="{{ .Permalink }}">
-          {{ range .Params.images }}
-          {{ $imgPath:= . }}
-          {{ if fileExists (add `assets/` $imgPath) }}
-          {{ $img:= resources.Get $imgPath }}
-          {{ $imageMD:= $img.Fill "700x330 webp" }}
-          {{ $imageSM:= $img.Fill "380x180 webp" }}
-          <picture>
-            <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 575px)">
-            <source srcset="{{ $imageMD.Permalink }}" media="(max-width: 991px)">
-            <img loading="lazy" decoding="async" src="{{$imageMD.RelPermalink}}" class="card-img-top img-fluid"
-              alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-          </picture>
-          {{ else }}
-          {{ with $resources.GetMatch $imgPath }}
-          {{ $img:= . }}
-          {{ $imageMD:= $img.Fill "700x330 webp" }}
-          {{ $imageSM:= $img.Fill "380x180 webp" }}
-          <picture>
-            <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 575px)">
-            <source srcset="{{ $imageMD.Permalink }}" media="(max-width: 991px)">
-            <img loading="lazy" decoding="async" src="{{$imageMD.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb"
-              width="{{$img.Width}}" height="{{$img.Height}}">
-          </picture>
-          {{ end }}
-          {{ end }}
-          {{ end }}</a>
-        </div>
-        {{ end }}
-        <!-- /post thumb -->
-
-        <div class="card-body">
-          <h3 class="mb-3"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h3>
-          <ul class="card-meta list-inline">
-            <li class="list-inline-item">
-              {{ if .Params.githubname }}
-              <a href="https://github.com/{{ .Params.githubname }}/" class="card-meta-author">
-                <img loading="lazy" decoding="async" width="24" height="24"
-                  src="https://github.com/{{ .Params.githubname }}.png" alt="{{ .Params.githubname }}"
-                  class="img-fluid">
-                <span>{{ .Params.author }}</span>
-              </a>
-              {{ else }}
-              <span>{{ .Params.author }}</span>
-              {{ end }}
-            </li>
-            <li class="list-inline-item">
-              <i class="far fa-clock"></i>{{ .Page.ReadingTime }} {{ i18n "minute_read" }}
-            </li>
-            <li class="list-inline-item">
-              <i class="far fa-calendar-alt"></i>{{ .PublishDate.Format "02 Jan, 2006" }}
-            </li>
-            <li class="list-inline-item">
-              <ul class="card-meta-tag list-inline">
-                {{ $filter:= site.Params.main_taxonomy }}
-                {{ if eq $filter "tag" }}
-                {{ $taxonomies := .Params.tags }}
-                {{ range $taxonomies }}
-                <li class="list-inline-item"><a href="{{ `tags/` | relLangURL }}{{ . | urlize | lower }}">{{ . |
-                    humanize }}</a></li>
-                {{ end }}
-                {{ else if eq $filter "category" }}
-                {{ $taxonomies := .Params.categories }}
-                {{ range $taxonomies }}
-                <li class="list-inline-item"><a href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}">{{ . |
-                    humanize }}</a></li>
-                {{ end }}
-                {{ end }}
-              </ul>
-            </li>
-          </ul>
-          <p>{{ .Summary }}</p>
-          <a href="{{.Permalink}}" class="btn btn-outline-primary">{{i18n "read_more"}}</a>
-        </div>
-      </article>
-      <!-- /full article -->
-      {{ end }}
       {{ end }}
 
       <!-- pagination -->
@@ -324,72 +316,71 @@
       {{ $upper_limit := (sub $paginator.TotalPages $adjacent_links) }}
       <!-- If there's more than one page. -->
       {{ if gt $paginator.TotalPages 1 }}
-      <ul class="pagination justify-content-center mt-4">
-        <!-- Previous page. -->
-        {{ if $paginator.HasPrev }}
-        <li class="page-item">
-          <a href="{{ $paginator.Prev.URL }}" class="page-link">
-            <i class="fas fa-angle-left"></i>
-          </a>
-        </li>
-        {{ end }}
-        <!-- Page numbers. -->
-        {{ range $paginator.Pagers }}
-        {{ $.Scratch.Set "page_number_flag" false }}
-        <!-- Advanced page numbers. -->
-        {{ if gt $paginator.TotalPages $max_links }}
-        <!-- Lower limit pages. -->
-        <!-- If the user is on a page which is in the lower limit.  -->
-        {{ if le $paginator.PageNumber $lower_limit }}
-        <!-- If the current loop page is less than max_links. -->
-        {{ if le .PageNumber $max_links }}
-        {{ $.Scratch.Set "page_number_flag" true }}
-        {{ end }}
-        <!-- Upper limit pages. -->
-        <!-- If the user is on a page which is in the upper limit. -->
-        {{ else if ge $paginator.PageNumber $upper_limit }}
-        <!-- If the current loop page is greater than total pages minus $max_links -->
-        {{ if gt .PageNumber (sub $paginator.TotalPages $max_links) }}
-        {{ $.Scratch.Set "page_number_flag" true }}
-        {{ end }}
-        <!-- Middle pages. -->
-        {{ else }}
-        {{ if and ( ge .PageNumber (sub $paginator.PageNumber $adjacent_links) ) ( le .PageNumber (add
-        $paginator.PageNumber $adjacent_links) ) }}
-        {{ $.Scratch.Set "page_number_flag" true }}
-        {{ end }}
-        {{ end }}
-        <!-- Simple page numbers. -->
-        {{ else }}
-        {{ $.Scratch.Set "page_number_flag" true }}
-        {{ end }}
-        <!-- Output page numbers. -->
-        {{ if eq ($.Scratch.Get "page_number_flag") true }}
-        <li class="page-item{{ if eq . $paginator }} page-item active {{ end }}">
-          <a href="{{ .URL }}" class="page-link">
-            {{ .PageNumber }}
-          </a>
-        </li>
-        {{ end }}
-        {{ end }}
-        <!-- Next page. -->
-        {{ if $paginator.HasNext }}
-        <li class="page-item">
-          <a href="{{ $paginator.Next.URL }}" class="page-link">
-            <i class="fas fa-angle-right"></i>
-          </a>
-        </li>
-        {{ end }}
-      </ul>
+        <ul class="pagination justify-content-center mt-4">
+          <!-- Previous page. -->
+          {{ if $paginator.HasPrev }}
+            <li class="page-item">
+              <a href="{{ $paginator.Prev.URL }}" class="page-link">
+                <i class="fas fa-angle-left"></i>
+              </a>
+            </li>
+          {{ end }}
+          <!-- Page numbers. -->
+          {{ range $paginator.Pagers }}
+            {{ $.Scratch.Set "page_number_flag" false }}
+            <!-- Advanced page numbers. -->
+            {{ if gt $paginator.TotalPages $max_links }}
+              <!-- Lower limit pages. -->
+              <!-- If the user is on a page which is in the lower limit.  -->
+              {{ if le $paginator.PageNumber $lower_limit }}
+                <!-- If the current loop page is less than max_links. -->
+                {{ if le .PageNumber $max_links }}
+                  {{ $.Scratch.Set "page_number_flag" true }}
+                {{ end }}
+                <!-- Upper limit pages. -->
+              <!-- If the user is on a page which is in the upper limit. -->
+              {{ else if ge $paginator.PageNumber $upper_limit }}
+                <!-- If the current loop page is greater than total pages minus $max_links -->
+                {{ if gt .PageNumber (sub $paginator.TotalPages $max_links) }}
+                  {{ $.Scratch.Set "page_number_flag" true }}
+                {{ end }}
+              <!-- Middle pages. -->
+              {{ else }}
+                {{ if and ( ge .PageNumber (sub $paginator.PageNumber $adjacent_links) ) ( le .PageNumber (add $paginator.PageNumber $adjacent_links) ) }}
+                  {{ $.Scratch.Set "page_number_flag" true }}
+                {{ end }}
+              {{ end }}
+              <!-- Simple page numbers. -->
+            {{ else }}
+              {{ $.Scratch.Set "page_number_flag" true }}
+            {{ end }}
+            <!-- Output page numbers. -->
+            {{ if eq ($.Scratch.Get "page_number_flag") true }}
+              <li class="page-item{{ if eq . $paginator }} page-item active {{ end }}">
+                <a href="{{ .URL }}" class="page-link">
+                  {{ .PageNumber }}
+                </a>
+              </li>
+            {{ end }}
+          {{ end }}
+          <!-- Next page. -->
+          {{ if $paginator.HasNext }}
+          <li class="page-item">
+            <a href="{{ $paginator.Next.URL }}" class="page-link">
+              <i class="fas fa-angle-right"></i>
+            </a>
+          </li>
+          {{ end }}
+        </ul>
       {{ end }}
 
     </div>
 
     <!-- right sidebar -->
     {{ if eq $sidebar "right" }}
-    <aside class="col-lg-4 {{.Scratch.Get `sidebar-margin`}}">
-      {{- partial "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) -}}
-    </aside>
+      <aside class="col-lg-4 {{.Scratch.Get `sidebar-margin`}}">
+        {{- partialCached "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) -}}
+      </aside>
     {{ end }}
     <!-- /right sidebar -->
   </div>

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -30,46 +30,23 @@
           <!-- list article -->
           <article class="card mb-4">
             <div class="row card-body">
-              {{ $resources:= .Resources }}
               <!-- post thumb -->
-              <div class="col-md-4 mb-4 mb-md-0">
-                {{ if .Params.images }}
+              {{ $thumbnail := partial "get-featured-image" . }}
+              {{ if $thumbnail }}
+                <div class="col-md-4 mb-4 mb-md-0">
                   <div class="post-slider slider-sm">
                     <a href="{{ .Permalink }}">
-                      {{ range .Params.images }}
-                        {{ $imgPath:= . }}
-                        {{ if fileExists (add `assets/` $imgPath) }}
-                          {{ $img:= resources.Get $imgPath }}
-                          {{ $imageSM:= $img.Fill "460x200 webp" }}
-                          {{ $imageXS:= $img.Fill "200x200 webp" }}
-                          <picture>
-                            <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 767px)">
-                            <source srcset="{{ $imageXS.Permalink }}" media="(min-width: 768px)">
-                            <source srcset="{{$img.RelPermalink}}">
-                            <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-                          </picture>
-                        {{ else }}
-                          {{ with $resources.GetMatch $imgPath }}
-                            {{ $img:= . }}
-                            {{ $imageSM:= $img.Fill "460x200 webp" }}
-                            {{ $imageXS:= $img.Fill "200x200 webp" }}
-                            <picture>
-                              <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 767px)">
-                              <source srcset="{{ $imageXS.Permalink }}" media="(min-width: 768px)">
-                              <source srcset="{{$img.RelPermalink}}">
-                              <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-                            </picture>
-                          {{ else }}
-                            <div class="image-fallback"><span>{{.Title | truncate 1}}</span></div>
-                          {{ end }}
-                        {{ end }}
-                      {{ end }}
+                      {{ partial "responsive-image" (dict
+                        "image" $thumbnail
+                        "fillSizes" (slice "200x200" "460x200")
+                        "sourceSizes" "(max-width: 768px) 200px, 460px"
+                        "altTitle" .Title
+                        )
+                      }}
                     </a>
                   </div>
-                {{ else }}
-                  <div class="image-fallback"><span>{{.Title | truncate 1}}</span></div>
-                {{ end }}
-              </div>
+                </div>
+              {{ end }}
               <!-- /post thumb -->
               <div class="col-md-8">
                 <h3 class="h4 mb-3"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h3>
@@ -130,49 +107,23 @@
           {{ range $paginator.Pages }}
             <div class="{{if $hasbar}}col-md-6{{else}}col-lg-4 col-md-6{{end}} mb-4">
               <article class="card h-100">
-                {{ $resources:= .Resources }}
                 <!-- post thumb -->
-                {{ if .Params.images }}
+                {{ $thumbnail := partial "get-featured-image" . }}
+                {{ if $thumbnail }}
                   <div class="post-slider slider-sm">
                     <a href="{{ .Permalink }}">
-                      {{ range .Params.images }}
-                        {{ $imgPath:= . }}
-                        {{ if fileExists (add `assets/` $imgPath) }}
-                          {{ $img:= resources.Get $imgPath }}
-                          {{ $imageLG:= $img.Fill "700x330 webp" }}
-                          {{ $imageMD:= $img.Fill "510x240 webp" }}
-                          {{ $imageSM:= $img.Fill "380x180 webp" }}
-                          <picture>
-                            <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
-                            <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
-                            <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
-                            <source srcset="{{$imageSM.RelPermalink}}">
-                            <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-                          </picture>
-                        {{ else }}
-                          {{ with $resources.GetMatch $imgPath }}
-                            {{ $img:= . }}
-                            {{ $imageLG:= $img.Fill "700x330 webp" }}
-                            {{ $imageMD:= $img.Fill "510x240 webp" }}
-                            {{ $imageSM:= $img.Fill "380x180 webp" }}
-                            <picture>
-                              <source srcset="{{ $imageSM.RelPermalink }}" media="(max-width: 575px)">
-                              <source srcset="{{ $imageMD.RelPermalink }}" media="(max-width: 767px)">
-                              <source srcset="{{ $imageLG.RelPermalink }}" media="(max-width: 991px)">
-                              <source srcset="{{$imageSM.RelPermalink}}">
-                              <img loading="lazy" decoding="async" src="{{$imageSM.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-                            </picture>
-                          {{ else }}
-                            <div class="image-fallback h-auto"><span>{{.Title | truncate 1}}</span></div>
-                          {{ end }}
-                        {{ end }}
-                      {{ end }}
+                      {{ partial "responsive-image" (dict
+                          "image" $thumbnail
+                          "fillSizes" (slice "380x180" "700x330")
+                          "sourceSizes" "(max-width: 400px) 380px, 700px"
+                          "altTitle" .Title
+                        )
+                      }}
                     </a>
                   </div>
-                {{ else }}
-                  <div class="image-fallback h-auto"><span>{{.Title | truncate 1}}</span></div>
                 {{ end }}
                 <!-- /post thumb -->
+
                 <div class="card-body">
                   <h3 class="h4 mb-3"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h3>
                   <ul class="card-meta list-inline">
@@ -221,38 +172,22 @@
         <!-- grid article -->
 
       {{ else }}
+
         {{ range $paginator.Pages }}
           <!-- full article -->
           <article class="card mb-4">
-            {{ $resources:= .Resources }}
             <!-- post thumb -->
-            {{ if .Params.images }}
+            {{ $thumbnail := partial "get-featured-image" . }}
+            {{ if $thumbnail }}
               <div class="post-slider slider-sm">
                 <a href="{{ .Permalink }}">
-                  {{ range .Params.images }}
-                    {{ $imgPath:= . }}
-                    {{ if fileExists (add `assets/` $imgPath) }}
-                      {{ $img:= resources.Get $imgPath }}
-                      {{ $imageMD:= $img.Fill "700x330 webp" }}
-                      {{ $imageSM:= $img.Fill "380x180 webp" }}
-                      <picture>
-                        <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 575px)">
-                        <source srcset="{{ $imageMD.Permalink }}" media="(max-width: 991px)">
-                        <img loading="lazy" decoding="async" src="{{$imageMD.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-                      </picture>
-                    {{ else }}
-                      {{ with $resources.GetMatch $imgPath }}
-                        {{ $img:= . }}
-                        {{ $imageMD:= $img.Fill "700x330 webp" }}
-                        {{ $imageSM:= $img.Fill "380x180 webp" }}
-                        <picture>
-                          <source srcset="{{ $imageSM.Permalink }}" media="(max-width: 575px)">
-                          <source srcset="{{ $imageMD.Permalink }}" media="(max-width: 991px)">
-                          <img loading="lazy" decoding="async" src="{{$imageMD.RelPermalink}}" class="card-img-top img-fluid" alt="post-thumb" width="{{$img.Width}}" height="{{$img.Height}}">
-                        </picture>
-                      {{ end }}
-                    {{ end }}
-                  {{ end }}
+                  {{ partial "responsive-image" (dict
+                      "image" $thumbnail
+                      "fillSizes" (slice "380x180" "700x330")
+                      "sourceSizes" "(max-width: 400px) 380px, 700px"
+                      "altTitle" .Title
+                    )
+                  }}
                 </a>
               </div>
             {{ end }}

--- a/layouts/partials/get-featured-image.html
+++ b/layouts/partials/get-featured-image.html
@@ -1,0 +1,40 @@
+{{/*
+    Get the featured image for a page.
+
+    It first tries to find the featured image for the page. If not
+    present, it falls back to the first page listed in the page
+    `images` collection.
+
+    {{ partial "get-featured-image" . }}
+
+    Parameters:
+    - (default): current page
+  */}}
+
+{{ $currentPage := . }}
+
+{{/*  default to thumbail image in page bundle (eg: file named '*thumbnail*.*' aside index.md)  */}}
+{{ $featuredImage := ($currentPage.Resources.ByType "image").GetMatch "*thumbnail*" }}
+{{/*  ... if not found, try to get image from page params  */}}
+{{ if not $featuredImage }}
+  {{ with $currentPage.Params.images }}
+    {{ $firstImage := (index . 0) }}
+    {{/*  ... if remote image...  */}}
+    {{ if findRE `^https?://` $firstImage }}
+      {{ $featuredImage = resources.GetRemote $firstImage }}
+    {{/*  ... else if found in [assets]/images/blog...  */}}
+    {{ else if (and (hasPrefix $firstImage "images/blog") (fileExists (add "assets/" $firstImage) ) ) }}
+      {{ $featuredImage = resources.Get $firstImage }}
+    {{/*  ... else, try to load a matching file...  */}}
+    {{ else }}
+      {{ $featuredImage = $currentPage.Resources.GetMatch $firstImage }}
+    {{ end }}
+
+    {{/*  if still don't have thumbnail, try to get image non non-page bundle  */}}
+    {{ if not $featuredImage }}
+      {{ $featuredImage = resources.Get $firstImage }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return $featuredImage }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,42 +2,40 @@
 <title>{{.Title | default site.Title}}</title>
 
 <!-- base url -->
-{{ if or (eq site.BaseURL "/") (eq site.BaseURL "http://localhost:1313/") (eq site.BaseURL "http://examplesite.org/")
-(eq site.BaseURL "https://examplesite.org/") (eq site.BaseURL "http://examplesite.com/") (eq site.BaseURL
-"https://examplesite.com/")}}{{else}}
-<base href="{{ .Permalink }}">
+{{ if or (eq site.BaseURL "/") (eq site.BaseURL "http://localhost:1313/") }}
+{{ else }}
+  <base href="{{ .Permalink }}">
 {{ end }}
 
 <!-- multilingual SEO optimizations -->
 {{ if .IsTranslated }}
-{{ range .AllTranslations }}
-<link rel="alternate" hreflang="{{.Lang}}" href="{{ .RelPermalink | absLangURL }}">
-{{ end }}
-<link rel="alternate" hreflang="x-default" href="{{ .RelPermalink | absLangURL }}">
+  {{ range .AllTranslations }}
+    <link rel="alternate" hreflang="{{.Lang}}" href="{{ .RelPermalink | absLangURL }}">
+  {{ end }}
+  <link rel="alternate" hreflang="x-default" href="{{ .RelPermalink | absLangURL }}">
 {{ end }}
 
 <!-- mobile responsive meta -->
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">
 <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" >
 
-{{ with site.Params.author }}
-<meta name="author" content="{{ . }}">{{ end }}
+{{ with site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
 {{ hugo.Generator }}
 
 <!-- favicon -->
 {{ $favicon:= site.Params.favicon }}
 {{ if $favicon }}
-{{ if fileExists (add `assets/` $favicon) }}
-{{ $favicon:= resources.Get $favicon }}
-{{ $favicon_16:= $favicon.Resize "16x png"}}
-{{ $favicon_32:= $favicon.Resize "32x png"}}
-{{ $favicon_180:= $favicon.Resize "180x png"}}
-<link rel="shortcut icon" href="{{$favicon_32.RelPermalink}}" type="image/x-icon">
-<link rel="icon" href="{{$favicon_32.RelPermalink}}" type="image/x-icon">
-<link rel="icon" type="image/png" sizes="16x16" href="{{$favicon_16.RelPermalink}}">
-<link rel="icon" type="image/png" sizes="32x32" href="{{$favicon_32.RelPermalink}}">
-<link rel="apple-touch-icon" sizes="180x180" href="{{$favicon_180.RelPermalink}}">
-{{ end }}
+  {{ if fileExists (add `assets/` $favicon) }}
+    {{ $favicon:= resources.Get $favicon }}
+    {{ $favicon_16:= $favicon.Resize "16x png"}}
+    {{ $favicon_32:= $favicon.Resize "32x png"}}
+    {{ $favicon_180:= $favicon.Resize "180x png"}}
+    <link rel="shortcut icon" href="{{$favicon_32.RelPermalink}}" type="image/x-icon">
+    <link rel="icon" href="{{$favicon_32.RelPermalink}}" type="image/x-icon">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{$favicon_16.RelPermalink}}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{$favicon_32.RelPermalink}}">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{$favicon_180.RelPermalink}}">
+  {{ end }}
 {{ end }}
 <link rel="manifest" href="{{`manifest.webmanifest` | relURL }}">
 <meta name="msapplication-TileColor" content="{{site.Params.variables.color_primary | default `#da532c`}}">
@@ -50,25 +48,22 @@
     {{ with $resources.GetMatch . }}
       {{ $img:= . }}
       {{ if (and (gt .Width 144) (gt .Height 144)) }}
-<meta name="twitter:card" content="summary{{ if (and (ge .Width 300) (gt .Height 157) (not (eq .Width .Height))) }}_large_image{{ end }}">
+        <meta name="twitter:card" content="summary{{ if (and (ge .Width 300) (gt .Height 157) (not (eq .Width .Height))) }}_large_image{{ end }}">
       {{ end }}
-<meta name="twitter:image" content="{{ $img.RelPermalink | absURL }}" />
-<meta property="og:image" content="{{ $img.RelPermalink | absURL }}" />
-<meta property="og:image:width" content="{{ .Width }}">
-<meta property="og:image:height" content="{{ .Height }}">
+        <meta name="twitter:image" content="{{ $img.RelPermalink | absURL }}" />
+        <meta property="og:image" content="{{ $img.RelPermalink | absURL }}" />
+        <meta property="og:image:width" content="{{ .Width }}">
+        <meta property="og:image:height" content="{{ .Height }}">
     {{ end }}
   {{ end }}
 {{ else }}
-<meta property="og:image" content="{{ site.Params.socialFallbackImage | absURL }}" />
+  <meta property="og:image" content="{{ site.Params.socialFallbackImage | absURL }}" />
 {{end}}
-
 <meta name="twitter:title" content="{{ with .Title }}{{ . }}{{ else }}{{ site.Title }}{{ end }}" />
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
-{{ with site.Social.twitter }}
-<meta name="twitter:site" content="@{{ . }}" />{{ end }}
+{{ with site.Social.twitter }}<meta name="twitter:site" content="@{{ . }}" />{{ end }}
 {{ range site.Authors }}
-{{ with .twitter }}
-<meta name="twitter:creator" content="@{{ . }}" />{{ end }}
+  {{ with .twitter }}<meta name="twitter:creator" content="@{{ . }}" />{{ end }}
 {{ end }}
 
 <meta property="og:site_name" content="{{ .Site.Title }}" />
@@ -89,7 +84,6 @@
   {{ end }}
   <meta property="article:section" content="post" />
   <meta itemprop="wordCount" content="{{ .WordCount }}">
-   else }}
   <meta property="og:type" content="website" />
 {{ end }}
 
@@ -100,8 +94,7 @@
   .Permalink) "404.php" ) -}} "noindex, nofollow" {{- else -}} "index, follow" {{ end }} />
 
 <!-- Meta Keywords/Tags for Users to search for in Search Engines -->
-<meta name="keywords" content="
- {{- with .Params.tags }}
+<meta name="keywords" content="{{- with .Params.tags }}
      {{- range $key, $item := . -}}
          {{- if ne $key 0 -}}
          ,
@@ -110,14 +103,13 @@
 
 <!-- Canonical URLs -->
 {{ if .Params.canonicalUrl }}
-<link rel="canonical" href="{{ .Params.canonicalUrl }}">
+  <link rel="canonical" href="{{ .Params.canonicalUrl }}">
 {{ else }}
-<link rel="canonical" href="{{ .Permalink }}">
+  <link rel="canonical" href="{{ .Permalink }}">
 {{ end }}
 <link rel="alternate" href="{{ .Permalink }}" hreflang="{{ .Site.LanguageCode }}" />
 
 <!-- Links to RSS Feed -->
 {{ range .AlternativeOutputFormats -}}
-{{ printf `
-<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
 {{ end -}}

--- a/layouts/partials/responsive-image.html
+++ b/layouts/partials/responsive-image.html
@@ -1,0 +1,36 @@
+{{/*
+  Generate responsive image with fallback for legacy browsers
+
+  {{ partial "responsive-image"
+    (dict
+      "image" $image
+      "imageSizes" (slice "400" "700")
+      "sourceSizes" "(max-width: 400px) 400px, 700px"
+      "altTitle" "This is the image alt & title value"
+    )
+  }}
+
+  Parameters:
+    - `image`: Hugo resource image
+    - `imageSizes`: array of responsive image sizes to use
+    - `sourceSizes`: string of sizes to use for the responsive breakpoints
+    - `altTitle`: string to use fo rthe alt text/title of the image
+*/}}
+
+{{ $image := .image }}
+{{ $fallbackImage := $image.Resize ( printf "%sx jpg" (index (last 1 .imageSizes) 0) ) }}
+<picture>
+  <source type="image/webp"
+          srcset="{{- with .imageSizes -}}
+            {{- range $i, $e := . -}}
+              {{- if ge $image.Width . -}}
+                {{- if $i }}, {{ end -}}{{- ($image.Resize (printf "%sx%s" . " webp") ).RelPermalink }} {{ . }}w
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}"
+          sizes="{{ .sourceSizes }}"
+  />
+  <img src="{{ $fallbackImage.RelPermalink | safeURL }}"
+       style="width:auto;" loading="lazy"
+       {{ with .altTitle }} title="{{ . }}" alt="{{ . }}"{{ end }}>
+</picture>

--- a/layouts/partials/responsive-image.html
+++ b/layouts/partials/responsive-image.html
@@ -8,6 +8,7 @@
       "fillSizes" (slice "380x180" "700x330")
       "sourceSizes" "(max-width: 400px) 400px, 700px"
       "altTitle" "This is the image alt & title value"
+      "cssImgOverride" "card-img-top img-fluid"
     )
   }}
 
@@ -16,8 +17,10 @@
     - `resizeSizes` | `fillSizes`: ONLY use one option, not both
       - `resizeSizes`: array of responsive image sizes to use for resizing
       - `fillSizes`: array of responsive image sizes to use for resizing
-    - `sourceSizes`: string of sizes to use for the responsive breakpoints
-    - `altTitle`: string to use fo rthe alt text/title of the image
+    - `sourceSizes`: (OPTIONAL) string of sizes to use for the responsive breakpoints
+        > NOTE: optional ONLY if [resizeSizes|fillSizes] have only one option
+    - `altTitle`: (OPTIONAL) string to use fo rthe alt text/title of the image
+    - `cssImgOverride`: (OPTIONAL) css styles to override for IMG element
 */}}
 
 {{ $image := .image }}
@@ -59,9 +62,10 @@
               {{- end -}}
             {{- end -}}
           {{- end -}}"
-          sizes="{{ .sourceSizes }}"
+          {{ with .sourceSizes }}sizes="{{ . }}"{{ end }}
   />
   <img src="{{ $fallbackImage.RelPermalink | safeURL }}"
-       style="width:auto;" loading="lazy"
+       {{ with .cssImgOverride }} class="{{ . }}"{{ else }} style="width:auto;"{{ end }}
+       loading="lazy"
        {{ with .altTitle }} title="{{ . }}" alt="{{ . }}"{{ end }}>
 </picture>

--- a/layouts/partials/responsive-image.html
+++ b/layouts/partials/responsive-image.html
@@ -48,10 +48,10 @@
   <source type="image/webp"
           srcset="{{- with $resizeWidths -}}
             {{- range $i, $e := . -}}
-              {{/*  if rendering with 'Fill' image processor...  */}}
+              {{- /*  if rendering with 'Fill' image processor...  */ -}}
               {{- with $fillSizes -}}
                 {{- if $i }}, {{ end -}}{{- ($image.Fill (printf "%s webp" (index $fillSizes $i)) ).RelPermalink }} {{ $e }}w
-              {{/*  ... else, assume rendering with `Resize` image processor...  */}}
+              {{- /*  ... else, assume rendering with `Resize` image processor...  */ -}}
               {{- else -}}
                 {{- if ge $image.Width . -}}
                   {{- if $i }}, {{ end -}}{{- ($image.Resize (printf "%sx webp" .) ).RelPermalink }} {{ $e }}w

--- a/layouts/partials/responsive-image.html
+++ b/layouts/partials/responsive-image.html
@@ -25,17 +25,16 @@
 {{/*  determine widths to parse  */}}
 {{ $resizeWidths := slice }}
 {{ $fillSizes := .fillSizes }}
-{{/*  if resizeSizes set...  */}}
+{{/*  if resizeSizes set, use those as resize widths...  */}}
 {{ with .resizeSizes }}
   {{ $resizeWidths = sort . }}
 {{ end }}
-{{/*  if fillSizes set...  */}}
+{{/*  if fillSizes set, use those widths as resize widths...  */}}
 {{ with .fillSizes }}
   {{ range sort . }}
     {{ $resizeWidths = $resizeWidths | append (index (split . "x") 0) }}
   {{ end }}
 {{ end }}
-{{ warnf "widths: %s" (delimit $resizeWidths ",") }}
 
 
 {{/*  validate exactly one of [].resizeSizes | .fillSizes] is set */}}
@@ -44,14 +43,15 @@
 {{ end }}
 
 
-
 {{ $fallbackImage := $image.Resize ( printf "%sx jpg" (index (last 1 $resizeWidths) 0) ) }}
 <picture>
   <source type="image/webp"
           srcset="{{- with $resizeWidths -}}
             {{- range $i, $e := . -}}
+              {{/*  if rendering with 'Fill' image processor...  */}}
               {{- with $fillSizes -}}
                 {{- if $i }}, {{ end -}}{{- ($image.Fill (printf "%s webp" (index $fillSizes $i)) ).RelPermalink }} {{ $e }}w
+              {{/*  ... else, assume rendering with `Resize` image processor...  */}}
               {{- else -}}
                 {{- if ge $image.Width . -}}
                   {{- if $i }}, {{ end -}}{{- ($image.Resize (printf "%sx webp" .) ).RelPermalink }} {{ $e }}w

--- a/layouts/partials/responsive-image.html
+++ b/layouts/partials/responsive-image.html
@@ -4,7 +4,8 @@
   {{ partial "responsive-image"
     (dict
       "image" $image
-      "imageSizes" (slice "400" "700")
+      "resizeSizes" (slice "400" "700")
+      "fillSizes" (slice "380x180" "700x330")
       "sourceSizes" "(max-width: 400px) 400px, 700px"
       "altTitle" "This is the image alt & title value"
     )
@@ -12,19 +13,49 @@
 
   Parameters:
     - `image`: Hugo resource image
-    - `imageSizes`: array of responsive image sizes to use
+    - `resizeSizes` | `fillSizes`: ONLY use one option, not both
+      - `resizeSizes`: array of responsive image sizes to use for resizing
+      - `fillSizes`: array of responsive image sizes to use for resizing
     - `sourceSizes`: string of sizes to use for the responsive breakpoints
     - `altTitle`: string to use fo rthe alt text/title of the image
 */}}
 
 {{ $image := .image }}
-{{ $fallbackImage := $image.Resize ( printf "%sx jpg" (index (last 1 .imageSizes) 0) ) }}
+
+{{/*  determine widths to parse  */}}
+{{ $resizeWidths := slice }}
+{{ $fillSizes := .fillSizes }}
+{{/*  if resizeSizes set...  */}}
+{{ with .resizeSizes }}
+  {{ $resizeWidths = sort . }}
+{{ end }}
+{{/*  if fillSizes set...  */}}
+{{ with .fillSizes }}
+  {{ range sort . }}
+    {{ $resizeWidths = $resizeWidths | append (index (split . "x") 0) }}
+  {{ end }}
+{{ end }}
+{{ warnf "widths: %s" (delimit $resizeWidths ",") }}
+
+
+{{/*  validate exactly one of [].resizeSizes | .fillSizes] is set */}}
+{{ if eq (len $resizeWidths) 0 }}
+  {{ errorf "Partial 'responsive-image' must have either 'resizeSizes' or 'fillSizes' set." }}
+{{ end }}
+
+
+
+{{ $fallbackImage := $image.Resize ( printf "%sx jpg" (index (last 1 $resizeWidths) 0) ) }}
 <picture>
   <source type="image/webp"
-          srcset="{{- with .imageSizes -}}
+          srcset="{{- with $resizeWidths -}}
             {{- range $i, $e := . -}}
-              {{- if ge $image.Width . -}}
-                {{- if $i }}, {{ end -}}{{- ($image.Resize (printf "%sx%s" . " webp") ).RelPermalink }} {{ . }}w
+              {{- with $fillSizes -}}
+                {{- if $i }}, {{ end -}}{{- ($image.Fill (printf "%s webp" (index $fillSizes $i)) ).RelPermalink }} {{ $e }}w
+              {{- else -}}
+                {{- if ge $image.Width . -}}
+                  {{- if $i }}, {{ end -}}{{- ($image.Resize (printf "%sx webp" .) ).RelPermalink }} {{ $e }}w
+                {{- end -}}
               {{- end -}}
             {{- end -}}
           {{- end -}}"

--- a/layouts/partials/responsive-image.html
+++ b/layouts/partials/responsive-image.html
@@ -46,7 +46,7 @@
 {{ end }}
 
 
-{{ $fallbackImage := $image.Resize ( printf "%sx jpg" (index (last 1 $resizeWidths) 0) ) }}
+{{ $fallbackImage := $image.Resize ( printf "%sx webp" (index (last 1 $resizeWidths) 0) ) }}
 <picture>
   <source type="image/webp"
           srcset="{{- with $resizeWidths -}}
@@ -58,6 +58,8 @@
               {{- else -}}
                 {{- if ge $image.Width . -}}
                   {{- if $i }}, {{ end -}}{{- ($image.Resize (printf "%sx webp" .) ).RelPermalink }} {{ $e }}w
+                {{- else -}}
+                  {{- if $i }}, {{ end -}}{{- ($image.Resize (printf "%dx%d webp" $image.Width $image.Height) ).RelPermalink }} {{ $e }}w
                 {{- end -}}
               {{- end -}}
             {{- end -}}

--- a/layouts/partials/widgets/recent-post.html
+++ b/layouts/partials/widgets/recent-post.html
@@ -4,28 +4,20 @@
   {{ "<!-- post-item -->" | safeHTML }}
   {{ range first 3 ( where site.RegularPages "Section" "!=" "dontshow" )}}
   {{ $resources:= .Resources }}
-  {{ $title:= .Title }}
+  {{ $title := .Title }}
   <article class="widget-card">
     <div class="d-flex">
-      {{ if .Params.images }}
-      <a href="{{ .Permalink }}">
-        {{ range first 1 .Params.images }}
-        {{ $imgPath:= . }}
-
-          {{ if fileExists (add `assets/` $imgPath) }}
-            {{ $img:= resources.Get $imgPath }}
-            {{ $imageXS:= $img.Fill "85x85 webp" }}
-            <img loading="lazy" decoding="async" width="{{$img.Width}}" height="{{$img.Height}}" src="{{$imageXS.RelPermalink}}" class="card-img-sm" loading="lazy" alt="post-thumb">
-          {{ else }}
-            {{ with $resources.GetMatch $imgPath }}
-              {{ $img:= . }}
-              {{ $imageXS:= $img.Fill "85x85 webp" }}
-              <img loading="lazy" decoding="async" width="{{$img.Width}}" height="{{$img.Height}}" src="{{$imageXS.RelPermalink}}" class="card-img-sm" loading="lazy" alt="post-thumb">
-            {{ else }}
-              <div class="image-fallback-sm"><span>{{$title | truncate 1}}</span></div>
-            {{ end }}
-          {{ end }}
-        {{ end }}</a>
+      {{ $thumbnail := partial "get-featured-image" . }}
+      {{ if $thumbnail }}
+        <a href="{{ .Permalink }}">
+          {{ partial "responsive-image" (dict
+              "image" $thumbnail
+              "fillSizes" (slice "85x85")
+              "altTitle" .Title
+              "cssImgOverride" "card-img-sm"
+            )
+          }}
+        </a>
       {{ else }}
         <div class="image-fallback-sm">
           <div class="image-fallback-sm"><span>{{.Title | truncate 1}}</span></div>


### PR DESCRIPTION
## Category

- [x] Theme fix

## Related issues

- fixes #144

## Contents of the Pull Request

This PR doubles as an optimization of build time & addressing multiple issues related to how responsive images are generated. Details below in the TL;DR.

Build optimization improvements addressed in two areas:

1. **Heavily leverage Hugo's `partialCached` over `partial`** for elements that are global & not unique to a page such as the sidebar (including categories, tags, and recent posts), footer, CSS, JS, etc. Before, Hugo had to regen these elements for every single page. But if they don't change, just gen them once, cache it, and let Hugo reuse the same element on every page.
1. **Rationalize responsive image generation.** The theme was generating images that were never used on the site. In general, only two sizes are used: mobile & desktop. Rationalized it down from 4 (_including 800w, 1200w & 1500w that were never being used_) to *usually* 2.

    > NOTE on "*usually*": While this slashed ~47% of the image processing, many content pages weren't resizing content images. For example, images referenced as `images/file.png` would get responsively resized, but if referenced as `./images/file.png` wouldn't. Fixing this gap resulted in adding tasks back to image processing. Regardless... appears net reduction still ~29%.

For local build/testing of the site, the first build can take a while (up to 5-10 minutes) to gen all the images involved in image processing (these are created in `./resources/_gen/images`), but subsequent builds are MUCH faster (sub 30s).

👉 Important note about build times... the way the current site updates are configured, it seems like a build can take a long time. Note that BUILDING the site is completely different from DEPLOYING the site. This PR only addresses the BUILD. I believe further optimizations can be made on both the BUILD & DEPLOYMENT aspects, but that's not part of the site content or Hugo theme (what this PR addresses).

Subsequent PR's will address process optimizations around builds & deployments. I need to see this working reliably first before moving onto those.

### TL;DR

Address poor build performance and image responsiveness, including:

- theme image processing issues addressed:
  - was processing images 4x yet 3 of which were never used because the resolution of the generated images is always greater than the max width of the content area... *IOW, these 3 images were garbage tasks*
  - was processing images 4x but without consideration of original image width - for instance, if the source image was 900px, it still resized it UP to 1200px & 1500px which is 100% unnecessary. Only resize down for responsive experiences
  - now images are ONLY resized **down** if source image width > desired image site for scenario
  - instead of 4x images generated for content pages, now max 3x
    - 2x images resized with optimal compression (*.webp)
    - 1x fallback image resized to handle caveman browsers (*.jpeg)
- switch theme partials that are global to all pages to build only once rather than for every page (ie: switch from `partial` to `partialCache`
- fix issue where content pages referencing images as `./images/file.ext` wouldn't get picked up by the image resizer & this potentially result in very large web-unfriendly images on page (image rendering hook now respects `./images/file.ext` & `images/file.ext`