### PR TITLE
Pins MGT CDN reference to v2

### DIFF
--- a/content/post/how-to-use-graph-toolkit-in-teams-app-inside-teams-tab/index.md
+++ b/content/post/how-to-use-graph-toolkit-in-teams-app-inside-teams-tab/index.md
@@ -78,7 +78,7 @@ Create a new page in a public folder as  `src\public\auth.html`. Copy below c
 <html>
     <head>
     <script src="https://unpkg.com/@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+    <script src="https://unpkg.com/@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
     </head>
     <body>
     <script>
@@ -326,7 +326,7 @@ In your `auth.html`, there would be below code
 <html>
     <head>
     <script src="https://unpkg.com/@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+    <script src="https://unpkg.com/@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
     </head>
     <body>
     <script>


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

## Contents of the Pull Request

Pins the MGT CDN reference to v2. MGT v3 with breaking changes is scheduled towards the end of the year. With the old reference, it could potentially break the code sample. The updated reference is pinned to v2 to ensure that the sample will work after MGT v3 was released.