### PR TITLE
Update CLI for M365 v6.6 release date

### DIFF
--- a/content/cli-for-microsoft-365/cli-for-microsoft-365-v6-6/index.md
+++ b/content/cli-for-microsoft-365/cli-for-microsoft-365-v6-6/index.md
@@ -1,6 +1,6 @@
 ---
 title: CLI for Microsoft 365 v6.6
-date: 2023-04-15T06:00:00.000Z
+date: 2023-04-14T17:00:00.000Z
 author: Jasey Waegebaert
 githubname: jwaegebaert
 categories:


### PR DESCRIPTION
## Category

- [x] Content fix
- [ ] New article

Changed the date of the CLI for Microsoft 365 announcement blog to today.
