### PR TITLE
Publishing PnP Weekly episode 228 - Merge in Tuesday 28th of Nov

### DIFF
--- a/content/microsoft-365-pnp-weekly/episode-228/index.md
+++ b/content/microsoft-365-pnp-weekly/episode-228/index.md
@@ -10,7 +10,7 @@ images:
 tags: []
 videos:
 - https://www.youtube.com/watch?v=TUUKrohvz7Y
-draft: true
+draft: false
 ---
 
 In this episode of the weekly discussion revolving around the latest news and topics on Microsoft 365, host – [Vesa Juvonen](http://twitter.com/vesajuvonen) (Microsoft) and [Waldek Mastykarz](http://twitter.com/waldekm) (Microsoft) are joined by [Cat Schneider](https://twitter.com/YerAWizardCat) Business Apps MVP, Power Platform developer.


### PR DESCRIPTION
## Category

- [ ] Content fix
- [x] New article

Publishing PR for the episode 228 - to be published in the Tuesday 28th of November so that the video and podcast is also out.